### PR TITLE
show dub install to the user

### DIFF
--- a/views/view_package.dt
+++ b/views/view_package.dt
@@ -117,6 +117,9 @@ block body
 		|	}
 		|}
 
+	p You can directly install it:
+	pre.code dub fetch #{packageName}
+
 	- if (versionInfo.readme.opt!string.length)
 		h2 Readme
 


### PR DESCRIPTION
It would be very nice if we could extend the installation instructions with a command that the users have to run as it is known from most package managers, but most notably `npm`.
I imagine the command to be similar to this:

```
dub fetch <package-name>
```

This also solves [one of the issues with the two different package formats](https://github.com/D-Programming-Language/dub/issues/789).

[Once `dub` supports `--save`](https://github.com/D-Programming-Language/dub/issues/790) it could even be used to replace the `package.json` example.

In case you don't like this suggestion, an alternative would be to have multiple tabs as [Awesome Vim](http://vimawesome.com/plugin/fugitive-vim) does.
