### PR TITLE
show by default sdl as package format

### DIFF
--- a/source/dubregistry/web.d
+++ b/source/dubregistry/web.d
@@ -127,7 +127,7 @@ class DubRegistryWebFrontend {
 	void getPackageFormat(string lang = null)
 	{
 		switch (lang) {
-			default: redirect("package-format?lang=json"); break;
+			default: redirect("package-format?lang=sdl"); break;
 			case "json": render!("package_format_json.dt"); break;
 			case "sdl": render!("package_format_sdl.dt"); break;
 		}


### PR DESCRIPTION
As proposed in #789 it makes sense to show the specification for SDLang by default to users.