### PR TITLE
fix menu wrap on narrow screens

### DIFF
--- a/public/styles/top_p.css
+++ b/public/styles/top_p.css
@@ -1,6 +1,6 @@
 
 span#search-query {
-    width: 13em;
+    width: 11.5em;
 }
 
 table {


### PR DESCRIPTION
- for screens above 66em (where we fold the search box) and below
  ~1100px the menu entries wrap to another line
- somewhat normal format for a 24" vertical screen
- fixed by reducing the extra wide search field

before
![menu](https://cloud.githubusercontent.com/assets/288976/15270927/ae42cd72-1a31-11e6-902e-64be75aa74f4.png)
after
![menu](https://cloud.githubusercontent.com/assets/288976/15270936/f4c318a6-1a31-11e6-8e7a-e1f25fec5b57.png)
