### PR TITLE
use MongoDB full text search

### DIFF
--- a/source/dubregistry/registry.d
+++ b/source/dubregistry/registry.d
@@ -106,8 +106,7 @@ class DubRegistry {
 	auto searchPackages(string query)
 	{
 		static struct Info { string name; DbPackageVersion _base; alias _base this; }
-		auto keywords = query.split();
-		return m_db.searchPackages(keywords).map!(p =>
+		return m_db.searchPackages(query).map!(p =>
 			Info(p.name, m_db.getVersionInfo(p.name, p.versions[$ - 1].version_)));
 	}
 


### PR DESCRIPTION
- native/indexed db support for searching
- supports full search syntax of MongoDB, i.e.
  `multiple words`, `"phrase search"`, `word -exclusion`
- higher weights for name and description
- stemming of search terms (uses english by default, can be overriden on
  a per package base, by adding a language field)
- ignores stopwords
- does not perform proximity search (typos), but our
  levenshtein search returned a lot of nonsense
- can't currently index the readme b/c it's not in the db, so people
  will have to optimize their short description to be nicely searchable
- don't index categories which should be an orthogonal search filter