### PR TITLE
Fixed logo href, not working in nested pages

### DIFF
--- a/views/layout.dt
+++ b/views/layout.dt
@@ -16,7 +16,7 @@ html
 			.helper
 				.helper.expand-container.active
 					.logo
-						a(href=".")
+						a(href="..")
 							img(id="logo", alt="DUB Logo", src="/images/dub-header.png")
 					a(href="#", title="Menu", class="hamburger expand-toggle")
 						span Menu


### PR DESCRIPTION
When clicking the logo in nested packages such as viewing a package, clicking the logo would result in a 404, because it wouldn't redirect to the root.