### PR TITLE
Use normal font-weight.

### DIFF
--- a/public/styles/top_p.css
+++ b/public/styles/top_p.css
@@ -41,11 +41,6 @@ table {
 }
 
 
-/* thinner font */
-body, .d_decl .quickindex {
-    font-weight: 300;
-}
-
 h2 {
     margin-top: 1.5em;
 }


### PR DESCRIPTION
This makes the site look consistent with main dlang.org site
and also much more readable.