### PR TITLE
Remove registered date from home view

### DIFF
--- a/views/home.dt
+++ b/views/home.dt
@@ -36,7 +36,7 @@ block body
 
 	table
 
-		- static immutable browse_kinds = ["name;Name", "updated;Last update", "added;Registered", ";Description"];
+		- static immutable browse_kinds = ["name;Name", "updated;Last update", ";Description"];
 		tr
 			- foreach (i, c; browse_kinds)
 				- auto cp = c.split(";");
@@ -68,7 +68,6 @@ block body
 						- else
 							| #{ver[0 .. 18]}&hellip;
 						span.dull.nobreak(title=formatDateTime(p.date))<> , #{formatFuzzyDate(p.date)}
-					td.nobreak(title=formatDateTime(pl.dateAdded))= formatDate(pl.dateAdded)
 					- if (desc.length <= 100)
 						td= desc
 					- else


### PR DESCRIPTION
Imho the registered date isn't very important when looking at the package overview and increases the "visual clutter".

Probably the download counts would be, but that would require more queries?
Is there any other good replacement that is a good indicator for a package?