### PR TITLE
align package description text to the left

### DIFF
--- a/public/styles/top.css
+++ b/public/styles/top.css
@@ -935,7 +935,7 @@ table td
 {
     border: none;
     border-bottom: 1px solid #E6E6E6;
-    text-align: justify;
+    text-align: left;
 }
 
 table th


### PR DESCRIPTION
_justify_ looks bad for several packages:

![justbad](https://cloud.githubusercontent.com/assets/16154339/17978526/deb009b4-6af6-11e6-8015-c5f7d1f7c1a4.png)