### PR TITLE
Implement a simple registry mirror mode

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -29,6 +29,7 @@ void startMonitoring()
 {
 	void monitorNewVersions()
 	{
+		sleep(2.minutes());
 		while(true){
 			if (s_mirror.length) s_registry.mirrorRegistry(URL(s_mirror));
 			else s_registry.checkForNewVersions();

--- a/source/app.d
+++ b/source/app.d
@@ -64,6 +64,7 @@ shared static this()
 	BitbucketRepository.register();
 
 	auto router = new URLRouter;
+	if (s_mirror.length) router.any("*", (req, res) { req.params["mirror"] = s_mirror; });
 	router.get("*", (req, res) { if (!s_checkTask.running) startMonitoring(); });
 
 	// VPM registry

--- a/source/app.d
+++ b/source/app.d
@@ -48,6 +48,10 @@ shared static this()
 	readOption("mirror", &s_mirror, "URL of a package registry that this instance should mirror (WARNING: will overwrite local database!)");
 	readOption("hostname", &hostname, "Domain name of this instance (default: code.dlang.org)");
 
+	// validate provided mirror URL
+	if (s_mirror.length)
+		validateMirrorURL(s_mirror);
+
 	version (linux) {
 		logInfo("Enforcing certificate trust.");
 		HTTPClient.setTLSSetupCallback((ctx) {

--- a/source/app.d
+++ b/source/app.d
@@ -6,6 +6,7 @@
 module app;
 
 import dubregistry.dbcontroller;
+import dubregistry.mirror;
 import dubregistry.repositories.bitbucket;
 import dubregistry.repositories.github;
 import dubregistry.registry;
@@ -22,13 +23,15 @@ import vibe.d;
 Task s_checkTask;
 DubRegistry s_registry;
 DubRegistryWebFrontend s_web;
+string s_mirror;
 
 void startMonitoring()
 {
 	void monitorNewVersions()
 	{
 		while(true){
-			s_registry.checkForNewVersions();
+			if (s_mirror.length) s_registry.mirrorRegistry(URL(s_mirror));
+			else s_registry.checkForNewVersions();
 			sleep(30.minutes());
 		}
 	}
@@ -38,6 +41,11 @@ void startMonitoring()
 shared static this()
 {
 	setLogFile("log.txt", LogLevel.diagnostic);
+
+	string hostname = "code.dlang.org";
+
+	readOption("mirror", &s_mirror, "URL of a package registry that this instance should mirror (WARNING: will overwrite local database!)");
+	readOption("hostname", &hostname, "Domain name of this instance (default: code.dlang.org)");
 
 	version (linux) {
 		logInfo("Enforcing certificate trust.");
@@ -58,18 +66,22 @@ shared static this()
 	auto router = new URLRouter;
 	router.get("*", (req, res) { if (!s_checkTask.running) startMonitoring(); });
 
-	// user management
-	auto udbsettings = new UserManSettings;
-	udbsettings.serviceName = "DUB - The D package registry";
-	udbsettings.serviceUrl = URL("http://code.dlang.org/");
-	udbsettings.serviceEmail = "noreply@vibed.org";
-	udbsettings.databaseURL = "mongodb://127.0.0.1:27017/vpmreg";
-	udbsettings.requireAccountValidation = false;
-	auto userdb = createUserManController(udbsettings);
-
 	// VPM registry
 	auto regsettings = new DubRegistrySettings;
 	s_registry = new DubRegistry(regsettings);
+
+	UserManController userdb;
+
+	if (!s_mirror.length) {
+		// user management
+		auto udbsettings = new UserManSettings;
+		udbsettings.serviceName = "DUB - The D package registry";
+		udbsettings.serviceUrl = URL("http://code.dlang.org/");
+		udbsettings.serviceEmail = "noreply@vibed.org";
+		udbsettings.databaseURL = "mongodb://127.0.0.1:27017/vpmreg";
+		udbsettings.requireAccountValidation = false;
+		userdb = createUserManController(udbsettings);
+	}
 
 	// web front end
 	s_web = router.registerDubRegistryWebFrontend(s_registry, userdb);
@@ -77,7 +89,7 @@ shared static this()
 
 	// start the web server
  	auto settings = new HTTPServerSettings;
-	settings.hostName = "code.dlang.org";
+	settings.hostName = hostname;
 	settings.bindAddresses = ["127.0.0.1"];
 	settings.port = 8005;
 	settings.sessionStore = new MemorySessionStore;

--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -75,8 +75,15 @@ class DbController {
 	void addPackage(ref DbPackage pack)
 	{
 		enforce(m_packages.findOne(["name": pack.name], ["_id": true]).isNull(), "A package with the same name is already registered.");
-		pack._id = BsonObjectID.generate();
+		if (pack._id == BsonObjectID.init)
+			pack._id = BsonObjectID.generate();
 		m_packages.insert(pack);
+	}
+
+	void addOrSetPackage(ref DbPackage pack)
+	{
+		enforce(pack._id != BsonObjectID.init, "Cannot update a packag with no ID.");
+		m_packages.update(["_id": pack._id], pack, UpdateFlags.upsert);
 	}
 
 	DbPackage getPackage(string packname)

--- a/source/dubregistry/mirror.d
+++ b/source/dubregistry/mirror.d
@@ -1,0 +1,82 @@
+/**
+*/
+module dubregistry.mirror;
+
+import dubregistry.registry;
+import dubregistry.dbcontroller;
+import userman.db.controller;
+import vibe.core.log;
+import vibe.data.bson;
+import vibe.http.client;
+import vibe.inet.url;
+import std.array : array;
+import std.datetime : SysTime;
+import std.encoding : sanitize;
+import std.format : format;
+
+
+void mirrorRegistry(DubRegistry registry, URL url)
+nothrow {
+	logInfo("Polling '%s' for updates...", url);
+	try {
+		bool[string] current_packs;
+		auto packs = requestHTTP(url ~ Path("packages/index.json")).readJson();
+		foreach (p; packs) {
+			auto pname = p.get!string;
+			current_packs[pname] = true;
+			try setPackage(registry, url, pname);
+			catch (Exception e) {
+				logError("Failed to add/update package '%s': %s", p, e.msg);
+				logDiagnostic("Full error: %s", e.toString().sanitize);
+			}
+		}
+
+		foreach (p; registry.availablePackages.array)
+			if (p !in current_packs) {
+				try removePackage(registry, p);
+				catch (Exception e) {
+					logError("Failed to remove package '%s': %s", p, e.msg);
+					logDiagnostic("Full error: %s", e.toString().sanitize);
+				}
+			}
+
+	} catch (Exception e) {
+		logError("Fetching updated packages failed: %s", e.msg);
+		logDiagnostic("Full error: %s", e.toString().sanitize);
+	}
+}
+
+private void setPackage(DubRegistry registry, URL src_reg, string pack_name)
+{
+	auto db = registry.db;
+
+	auto info = requestHTTP(src_reg ~ Path("packages/"~pack_name~".json")).readJson();
+
+	DbPackage pack;
+	pack._id = BsonObjectID.fromString(info["id"].get!string);
+	pack.name = info["name"].get!string;
+	pack.owner = BsonObjectID.fromString(info["owner"].get!string);
+	pack.repository = info["repository"];
+	foreach (jv; info["versions"]) {
+		DbPackageVersion v;
+		v.version_ = jv["version"].get!string;
+		v.readme = jv["readme"].opt!string;
+		v.date = SysTime.fromISOExtString(jv["date"].get!string);
+
+		auto info = jv.get!(Json[string]).dup;
+		info.remove("readme");
+		info.remove("url");
+		info.remove("date");
+		v.info = Json(info);
+		pack.versions ~= v;
+	}
+	logInfo("Updating package '%s'", pack_name);
+	db.addOrSetPackage(pack);
+}
+
+private void removePackage(DubRegistry registry, string pack_name)
+{
+	logInfo("Removing package '%s", pack_name);
+	auto uid = registry.db.getPackage(pack_name).owner;
+	registry.removePackage(pack_name, User.ID(uid));
+}

--- a/source/dubregistry/registry.d
+++ b/source/dubregistry/registry.d
@@ -58,6 +58,8 @@ class DubRegistry {
 		m_updateQueueTask = runTask(&processUpdateQueue);
 	}
 
+	@property DbController db() nothrow { return m_db; }
+
 	@property auto availablePackages()
 	{
 		return m_db.getAllPackages();

--- a/source/dubregistry/web.d
+++ b/source/dubregistry/web.d
@@ -278,7 +278,8 @@ class DubRegistryWebFrontend {
 		if (!getPackageInfo(pname, ver, packageInfo, versionInfo))
 			return;
 
-		auto user = m_userman.getUser(User.ID.fromString(packageInfo["owner"].get!string));
+		User user;
+		if (m_userman) user = m_userman.getUser(User.ID.fromString(packageInfo["owner"].get!string));
 
 		if (ext == "zip") {
 			if (pname.canFind(":")) return;

--- a/views/docs.commandline.dt
+++ b/views/docs.commandline.dt
@@ -5,6 +5,7 @@ block title
 
 block body
 	- import dub.commandline;
+	- import std.string : split;
 	- void writeIndentedLine(string line)
 		- while (line.length > 0 && line[0] == ' ')
 			| &nbsp;

--- a/views/download.dt
+++ b/views/download.dt
@@ -17,7 +17,7 @@ block body
 	- typeof(info.versions[0]) latest_release, latest_prerelease;
 	- foreach_reverse (v; info.versions)
 		- if (isPreReleaseVersion(v.id))
-			- if (latest_prerelease.id.empty) latest_prerelease = v;
+			- if (!latest_prerelease.id.length) latest_prerelease = v;
 		- else
 			- latest_release = v;
 			- break;

--- a/views/home.dt
+++ b/views/home.dt
@@ -4,36 +4,42 @@ block title
 	- import dubregistry.viewutils;
 	- import dubregistry.web;
 	- import vibe.data.json;
-	- import std.string : replace;
+	- import std.string : replace, split;
 	- auto title = "Find, Use and Share DUB Packages";
 	script(type="application/javascript", src="scripts/home.js")
 	script(type="application/javascript").
 		window.categories = #{serializeToJson(categories).toString()};
 
 block body
-	p Welcome to DUB, the D package registry. The following list shows all available packages:
-
 	- auto category = req.query.get("category", null);
 	- auto sort_mode = req.query.get("sort", "updated");
-	form#category-form(method="GET", action="")
-		input(type="hidden", name="sort", value=sort_mode)
-		p Select category:
-			select#category(name="category", size="1", onChange='document.getElementById("category-form").submit()')
-				- void outputCat(Category cat)
-					- if (!cat)
-						option(value="") All packages
-					- else
-						option(value=cat.name, selected=cat.name==category)= cat.indentedDescription
-					- if (!cat || cat.subCategories.length)
-						- foreach (c; cat ? cat.subCategories : categories)
-							- outputCat(c);
-				- outputCat(null);
-			button#category-submit(type="submit") Update
-	#category-dynamic-form(style="display: none")
-		p Select category:
-			- foreach (i; 0 .. 6)
-				select(id="categories_#{i}", name="categories_#{i}", onChange='setCategoryFromSelector(#{i})')
-		:javascript setupCategoryForm();
+
+	- auto mirror = req.params.get("mirror", "");
+	- if (mirror.length)
+		p This is a mirror of #[a(href=mirror)= mirror].
+	- else
+		p Welcome to DUB, the D package registry. The following list shows all available packages:
+
+		form#category-form(method="GET", action="")
+			input(type="hidden", name="sort", value=sort_mode)
+			p Select category:
+				select#category(name="category", size="1", onChange='document.getElementById("category-form").submit()')
+					- void outputCat(Category cat)
+						- if (!cat)
+							option(value="") All packages
+						- else
+							option(value=cat.name, selected=cat.name==category)= cat.indentedDescription
+						- if (!cat || cat.subCategories.length)
+							- foreach (c; cat ? cat.subCategories : categories)
+								- outputCat(c);
+					- outputCat(null);
+				button#category-submit(type="submit") Update
+		#category-dynamic-form(style="display: none")
+			p Select category:
+				- foreach (i; 0 .. 6)
+					select(id="categories_#{i}", name="categories_#{i}", onChange='setCategoryFromSelector(#{i})')
+			:javascript
+				setupCategoryForm();
 
 	table
 
@@ -77,10 +83,8 @@ block body
 
 	p Found #{packages.length} packages.
 
-	- if( req.session )
-		p
-			a(href="my_packages") Manage my packages
-	- else
-		p Please
-			a(href="login?redirect=/my_packages") log in
-			| to manage your own packages.
+	- if (!mirror.length)
+		- if (req.session)
+			p: a(href="my_packages") Manage my packages
+		- else
+			p Please #[a(href="login?redirect=/my_packages") log in] to manage your own packages.

--- a/views/layout.dt
+++ b/views/layout.dt
@@ -13,7 +13,8 @@ html
 	body#Home.doc
 		script document.body.className += ' have-javascript'
 		#top
-			include layout.inc.menu
+			- if ("mirror" !in req.params)
+				include layout.inc.menu
 		#content
 			block body
 

--- a/views/layout.dt
+++ b/views/layout.dt
@@ -13,65 +13,7 @@ html
 	body#Home.doc
 		script document.body.className += ' have-javascript'
 		#top
-			.helper
-				.helper.expand-container.active
-					.logo
-						a(href="#{req.rootDir}")
-							img(id="logo", alt="DUB Logo", src="#{req.rootDir}images/dub-header.png")
-					a(href="#", title="Menu", class="hamburger expand-toggle")
-						span Menu
-					#cssmenu
-						- import std.algorithm.searching : startsWith;
-						- import std.range : empty;
-						- import std.string : split;
-						- import std.typecons : tuple;
-						- auto listitems = [tuple("Packages", [""]), tuple("Documentation", ["Getting Started;getting_started", "Command line documentation;docs/commandline", "Development;develop", "Package format (JSON);package-format?lang=json", "Package format (SDLang);package-format?lang=sdl"]), tuple("About",  ["Forums;http://forum.rejectedsoftware.com/groups/rejectedsoftware.dub", "Bug tracker (website);https://github.com/dlang/dub-registry/issues", "Bug tracker (DUB);https://github.com/dlang/dub/issues", "Github repository (website);https://github.com/dlang/dub-registry", "GitHub repository (DUB);https://github.com/dlang/dub"]), tuple("Download", ["download"])];
-						- if( req.session )
-							- listitems ~= tuple("My account", ["Manage packages;my_packages", "Edit profile;profile", "Log out;logout"]);
-						- else
-							- auto loginURL = req.requestURL;
-							- if (loginURL == "/")
-								- loginURL = "/my_packages";
-							- listitems ~= tuple("Log in", ["login?redirect=" ~ loginURL]);
-						ul
-							- foreach(items; listitems)
-								- if(items[1].length < 2)
-									- bool active = startsWith(req.path[1..$], items[1][0]);
-									- if( items[1][0].empty ) active = req.path == "/";
-									li(class=(active ? "active" : ""))
-										- if (!(items[1][0].length > 4 && items[1][0][0..4] == "http"))
-											- items[1][0] = req.rootDir ~ items[1][0];
-										a(href="#{items[1][0]}")
-											span=items[0]
-								- else
-									- bool active = false;
-									- foreach(itm; items[1])
-										- if (startsWith(req.path[1..$], split(itm, ";")[1])) active = true;
-									li(class=(active ? "expand-container active" : "expand-container"))
-										a.expand-toggle(href="#")
-											span=items[0]
-										ul.expand-content
-											- foreach(itm; items[1])
-												- auto parts = split(itm, ";");
-												- bool active_item = startsWith(req.path[1..$], parts[1]);
-												li(class=(active_item ? "active" : ""))
-													- if (!(parts[1].length > 4 && parts[1][0..4] == "http"))
-														- parts[1] = req.rootDir ~ parts[1];
-													a(href="#{parts[1]}")
-														span=parts[0]
-
-
-					.search-container.expand-container
-						a.expand-toggle(href="search.html", title="Search")
-							span Search
-						#search-box
-							form(method="GET", action="#{req.rootDir}search")
-								span#search-query
-									input#q(name="q", placeholder="Search for a package")
-								span#search-submit
-									button(type="submit")
-										i.fa.fa-search
-
+			include layout.inc.menu
 		#content
 			block body
 

--- a/views/layout.inc.menu.dt
+++ b/views/layout.inc.menu.dt
@@ -1,0 +1,57 @@
+.helper
+	.helper.expand-container.active
+		.logo
+			a(href="#{req.rootDir}")
+				img(id="logo", alt="DUB Logo", src="#{req.rootDir}images/dub-header.png")
+		a(href="#", title="Menu", class="hamburger expand-toggle")
+			span Menu
+		#cssmenu
+			- import std.algorithm.searching : startsWith;
+			- import std.range : empty;
+			- import std.string : split;
+			- import std.typecons : tuple;
+			- auto listitems = [tuple("Packages", [""]), tuple("Documentation", ["Getting Started;getting_started", "Command line documentation;docs/commandline", "Development;develop", "Package format (JSON);package-format?lang=json", "Package format (SDLang);package-format?lang=sdl"]), tuple("About",  ["Forums;http://forum.rejectedsoftware.com/groups/rejectedsoftware.dub", "Bug tracker (website);https://github.com/dlang/dub-registry/issues", "Bug tracker (DUB);https://github.com/dlang/dub/issues", "Github repository (website);https://github.com/dlang/dub-registry", "GitHub repository (DUB);https://github.com/dlang/dub"]), tuple("Download", ["download"])];
+			- if( req.session )
+				- listitems ~= tuple("My account", ["Manage packages;my_packages", "Edit profile;profile", "Log out;logout"]);
+			- else
+				- auto loginURL = req.requestURL;
+				- if (loginURL == "/")
+					- loginURL = "/my_packages";
+				- listitems ~= tuple("Log in", ["login?redirect=" ~ loginURL]);
+			ul
+				- foreach(items; listitems)
+					- if(items[1].length < 2)
+						- bool active = startsWith(req.path[1..$], items[1][0]);
+						- if( items[1][0].empty ) active = req.path == "/";
+						li(class=(active ? "active" : ""))
+							- if (!(items[1][0].length > 4 && items[1][0][0..4] == "http"))
+								- items[1][0] = req.rootDir ~ items[1][0];
+							a(href="#{items[1][0]}")
+								span=items[0]
+					- else
+						- bool active = false;
+						- foreach(itm; items[1])
+							- if (startsWith(req.path[1..$], split(itm, ";")[1])) active = true;
+						li(class=(active ? "expand-container active" : "expand-container"))
+							a.expand-toggle(href="#")
+								span=items[0]
+							ul.expand-content
+								- foreach(itm; items[1])
+									- auto parts = split(itm, ";");
+									- bool active_item = startsWith(req.path[1..$], parts[1]);
+									li(class=(active_item ? "active" : ""))
+										- if (!(parts[1].length > 4 && parts[1][0..4] == "http"))
+											- parts[1] = req.rootDir ~ parts[1];
+										a(href="#{parts[1]}")
+											span=parts[0]
+
+		.search-container.expand-container
+			a.expand-toggle(href="search.html", title="Search")
+				span Search
+			#search-box
+				form(method="GET", action="#{req.rootDir}search")
+					span#search-query
+						input#q(name="q", placeholder="Search for a package")
+					span#search-submit
+						button(type="submit")
+							i.fa.fa-search

--- a/views/view_package.dt
+++ b/views/view_package.dt
@@ -145,6 +145,8 @@ block body
 			em= vs
 		- else
 			a(href='#{req.rootDir}packages/#{urlEncode(packageName)}/#{vs}')= vs
+		|  
 
 	script(type="application/javascript", src="/scripts/clipboard.min.js")
-	:javascript new Clipboard('.btn-clipboard');
+	:javascript
+		new Clipboard('.btn-clipboard');

--- a/views/view_package.dt
+++ b/views/view_package.dt
@@ -71,9 +71,10 @@ block body
 				td Authors
 				td= join(map!(a => a.get!string)(pa.get!(Json[])), ", ")
 
-		tr
-			td Registered by
-			td= user.fullName.length ? user.fullName : user.name
+		- if (user.id != User.ID.init)
+			tr
+				td Registered by
+				td= user.fullName.length ? user.fullName : user.name
 
 		- if (versionInfo["subPackages"].opt!(Json[]).length)
 			tr


### PR DESCRIPTION
Can be enabled with `./dub-registry --mirror https://code.dlang.org/`

The most obvious improvement will be to add an API endpoint to receive a complete database dump instead of querying each package individually.