### PR TITLE
Add an /api/packages/dump REST API endpoint.

### DIFF
--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -91,6 +91,11 @@ class DbController {
 		return m_packages.find(Bson.emptyObject, ["name": 1]).map!(p => p["name"].get!string)();
 	}
 
+	auto getPackageDump()
+	{
+		return m_packages.find(Bson.emptyObject).map!(p => p.deserializeBson!DbPackage);
+	}
+
 	auto getUserPackages(BsonObjectID user_id)
 	{
 		return m_packages.find(["owner": user_id], ["name": 1]).map!(p => p["name"].get!string)();

--- a/source/dubregistry/registry.d
+++ b/source/dubregistry/registry.d
@@ -63,6 +63,11 @@ class DubRegistry {
 		return m_db.getAllPackages();
 	}
 
+	auto getPackageDump()
+	{
+		return m_db.getPackageDump();
+	}
+
 	void triggerPackageUpdate(string pack_name)
 	{
 		synchronized (m_updateQueueMutex) {


### PR DESCRIPTION
This fetches the whole package database in a single request. The response is forced to be GZIP compressed to avoid excessive bandwidth use (currently 20MB uncompressed for ~1000 packages, 1.3MB compressed).