### PR TITLE
Display download statistics on 'Edit package' page

### DIFF
--- a/views/my_packages.package.dt
+++ b/views/my_packages.package.dt
@@ -19,6 +19,14 @@ block body
 		dt Latest version
 		dd= latest.type == Json.Type.Object ? latest["version"].opt!string : "-"
 
+		- auto stats = registry.getPackageStats(packageName)["downloads"];
+		dt Downloads
+		dd
+			| Total: #{stats["total"].to!string},
+			| monthly: #{stats["monthly"].to!string},
+			| weekly: #{stats["weekly"].to!string},
+			| daily: #{stats["daily"].to!string}
+
 	form(method="POST", action="#{req.rootDir}my_packages/#{packageName}/remove")
 		button(type="submit") Remove this package
 


### PR DESCRIPTION
Looks like this:
![dub registry stats mypackage](https://cloud.githubusercontent.com/assets/27865436/26166456/e4803aa4-3b33-11e7-8711-fd0e711c452d.png)

It works only on 'Edit package' page which means only package owners can see it. I don't want to add this to main package page `'view_package.dt'` yet, because it looks ugly.
Implements #169 (at least partially).