### PR TITLE
Fixing deprecated warnings

### DIFF
--- a/source/dubregistry/cache.d
+++ b/source/dubregistry/cache.d
@@ -80,7 +80,7 @@ class URLCache {
 						continue;
 					} else {
 						auto data = be["data"].get!BsonBinData().rawData();
-						scope tmpresult = new MemoryStream(cast(ubyte[])data, false);
+						scope tmpresult = createMemoryStream(cast(ubyte[])data, false);
 						callback(tmpresult);
 						return;
 					}
@@ -103,7 +103,7 @@ class URLCache {
 							logDiagnostic("Cache HIT: %s", url.toString());
 							res.dropBody();
 							auto data = be["data"].get!BsonBinData().rawData();
-							result = new MemoryStream(cast(ubyte[])data, false);
+							result = createMemoryStream(cast(ubyte[])data, false);
 							break;
 						case HTTPStatus.notFound:
 							res.dropBody();
@@ -124,13 +124,13 @@ class URLCache {
 							auto pet = "ETag" in res.headers;
 							if (pet || mode == CacheMatchMode.always) {
 								logDiagnostic("Cache MISS: %s", url.toString());
-								auto dst = new MemoryOutputStream;
-								dst.write(res.bodyReader);
+								auto dst = createMemoryOutputStream();
+								res.bodyReader.pipe(dst);
 								auto rawdata = dst.data;
 								if (pet) entry.etag = *pet;
 								entry.data = BsonBinData(BsonBinData.Type.Generic, cast(immutable)rawdata);
 								m_entries.update(["_id": entry._id], entry, UpdateFlags.Upsert);
-								result = new MemoryStream(rawdata, false);
+								result = createMemoryStream(rawdata, false);
 								break;
 							}
 

--- a/source/dubregistry/notificationcenter.d
+++ b/source/dubregistry/notificationcenter.d
@@ -51,7 +51,7 @@ class NotificationCenter {
 		mail.headers["To"] = format("%s <%s>", user.fullName, user.email); // FIXME: sanitize/escape user.fullName
 		mail.headers["Subject"] = format("[%s] Errors in new version %s", package_name, branch_or_version);
 
-		auto dst = new MemoryOutputStream;
+		auto dst = createMemoryOutputStream();
 		dst.compileDietFile!("dubregistry.mail.package-version-errors.dt", user, settings, package_name, branch_or_version, errors);
 		mail.bodyText = cast(string)dst.data;
 
@@ -84,7 +84,7 @@ class NotificationCenter {
 				mail.headers["To"] = format("%s <%s>", user.fullName, user.email); // FIXME: sanitize/escape user.fullName
 				mail.headers["Subject"] = format("Weekly deprecation warnings reminder");
 
-				auto dst = new MemoryOutputStream;
+				auto dst = createMemoryOutputStream();
 				dst.compileDietFile!("dubregistry.mail.package-deprecation-warnings.dt", user, settings, deprecations);
 				mail.bodyText = cast(string)dst.data;
 


### PR DESCRIPTION
Fixes:
```
source/dubregistry/cache.d(83,25): Deprecation: constructor vibe.stream.memory.MemoryStream.this is deprecated - Use createMemoryStream instead.
source/dubregistry/cache.d(106,17): Deprecation: constructor vibe.stream.memory.MemoryStream.this is deprecated - Use createMemoryStream instead.
source/dubregistry/cache.d(127,20): Deprecation: constructor vibe.stream.memory.MemoryOutputStream.this is deprecated - Use createMemoryOutputStream isntead.
source/dubregistry/cache.d(128,18): Deprecation: function vibe.core.stream.OutputStream.write is deprecated - Use pipe(source, sink) instead.
source/dubregistry/cache.d(133,18): Deprecation: constructor vibe.stream.memory.MemoryStream.this is deprecated - Use createMemoryStream instead.
source/dubregistry/notificationcenter.d(54,14): Deprecation: constructor vibe.stream.memory.MemoryOutputStream.this is deprecated - Use createMemoryOutputStream isntead.
source/dubregistry/notificationcenter.d(87,16): Deprecation: constructor vibe.stream.memory.MemoryOutputStream.this is deprecated - Use createMemoryOutputStream isntead.
```