### PR TITLE
New layout of package page

### DIFF
--- a/public/styles/common.css
+++ b/public/styles/common.css
@@ -94,7 +94,7 @@ p.warn {
 /********************/
 
 div#content {
-	padding: 12pt;
+	padding: 0.01em;
 	clear: both;
 }
 
@@ -158,10 +158,6 @@ h3 {
 	border: 1px solid #ddd;
 }*/
 
-#content ul.pageNav.perPage:before {
-	content: "Per Page: ";
-	display: inline;
-}
 #content ul.pageNav {
 	list-style: none;
 	padding: 0;
@@ -178,11 +174,25 @@ ul.pageNav li.selected {
 	padding: 0 2pt;
 }
 
-
-@media (min-width: 600pt) {
-	div#content { padding: 12pt 10%; }
+div#content {
+	margin: 0 auto;
 }
 
+@media (max-width: 768px) {
+	div#content { margin: 0 1em; }
+}
+
+@media (min-width: 768px) {
+	div#content { width: 740px; }
+}
+
+@media (min-width: 992px) {
+	div#content { width: 960px; }
+}
+
+@media (min-width: 1200px) {
+	div#content { width: 1160px; }
+}
 
 /********************/
 /* Buttons          */
@@ -235,3 +245,103 @@ button {
 #copy-shields input {
     width: 280px;
 }
+
+@media only screen and (min-width: 54em) {
+	div.main {
+		float: left;
+		position: relative;
+		width: 70%;
+	}
+
+	div.packageInfo {
+		float: right;
+		width: 30%;
+	}
+}
+
+div.packageInfo > *:first-child {
+	margin-top: 0 !important;
+}
+
+div.packageInfo > ul {
+	margin-left: 0 !important;
+	margin-bottom: 1em;
+}
+
+div.packageInfo > * {
+	color: rgba(0,0,0,0.7);
+	line-height: 2em;
+}
+
+div.packageInfo > p,
+div#versions,
+div#versions > p {
+	margin-top: 0 !important;
+	margin-bottom: 0.5em !important;
+}
+
+div.packageInfo > *,
+ul.unmarkedList > li {
+	white-space: nowrap;
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
+ul.unmarkedList > li {
+	list-style: none;
+	border-bottom: 1px solid rgba(0,0,0,0.1);
+	margin-bottom: 0 !important;
+}
+
+ul.unmarkedList > li:last-child {
+	border-bottom: 0;
+}
+
+ul.unmarkedList > li:hover,
+.wrap {
+	overflow: visible !important;
+	text-overflow: inherit !important;
+	white-space: normal !important;
+}
+
+.wrap {
+	line-height: 1.5em !important;
+}
+
+.wrap span {
+	white-space: nowrap;
+}
+
+#stats ul li {
+	line-height: 1em;
+	border-style: none;
+	margin-bottom: 0;
+}
+
+#versions strong {
+	margin: 0;
+}
+#versions table,
+#showAll{
+	line-height: 1em;
+	margin: 0 2em;
+	font-family: monospace;
+}
+
+#versions td {
+	padding: 0.5em 0;
+	width: 1%;
+	border: none;
+	border-bottom: 1px solid rgb(230,230,230);
+}
+
+.badge {
+	background-color: #B04A43;
+	color: #FFF;
+	font-size: 50%;
+	border-radius: 2px;
+	vertical-align: 30%;
+	padding: 0.1em 0.3em;
+}
+
+span.light { opacity: 0.8; }

--- a/source/dubregistry/web.d
+++ b/source/dubregistry/web.d
@@ -60,9 +60,6 @@ class DubRegistryWebFrontend {
 		import std.algorithm.comparison : min;
 		import std.algorithm.iteration : filter, map;
 
-		if (limit == 0) // prevent division by zero
-			limit = 20;
-
 		static struct Info {
 			Json[] packages;
 			size_t packageCount;
@@ -215,13 +212,31 @@ class DubRegistryWebFrontend {
 			}
 
 			auto packageName = pname;
+			auto registry = m_registry;
 			auto readmeContents = m_registry.getReadme(versionInfo, packageInfo["repository"].deserializeJson!DbRepository);
-			render!("view_package.dt", packageName, user, packageInfo, versionInfo, readmeContents, urlFilter);
+			render!("view_package.dt", packageName, user, packageInfo, versionInfo, readmeContents, urlFilter, registry);
 		}
 	}
 
-	private bool getPackageInfo(string pack_name, string pack_version, out PackageInfo pkg_info, out PackageVersionInfo ver_info)
-	{
+	@path("/packages/:packname/versions")
+	void getAllPackageVersions(HTTPServerRequest req, HTTPServerResponse res, string _packname) {
+		import std.algorithm : canFind;
+
+		auto pname = _packname;
+
+		auto ppath = _packname.urlDecode().split(":");
+		auto packageInfo = m_registry.getPackageInfo(ppath[0]);
+
+		auto packageName = pname;
+		auto registry = m_registry;
+		render!("view_package.versions.dt",
+			packageName,
+			packageInfo,
+			registry);
+	}
+
+	private bool getPackageInfo(string pack_name, string pack_version, out PackageInfo pkg_info, out PackageVersionInfo ver_info) {
+		import std.algorithm : map;
 		auto ppath = pack_name.urlDecode().split(":");
 
 		pkg_info = m_registry.getPackageInfo(ppath[0]);

--- a/views/home.dt
+++ b/views/home.dt
@@ -16,11 +16,6 @@ block body
 	- auto category = req.query.get("category", null);
 	- auto sort_mode = req.query.get("sort", "updated");
 
-	- string makeHomeURL(string sort, string category, ulong skip, ulong limit) {
-	-   import std.conv : to;
-	-   return "?sort=" ~ sort ~ "&category=" ~ category ~ "&skip=" ~ skip.to!string ~ "&limit=" ~ limit.to!string;
-	- }
-
 	- auto mirror = req.params.get("mirror", "");
 	- if (mirror.length)
 		p This is a mirror of #[a(href=mirror)= mirror].
@@ -29,7 +24,6 @@ block body
 
 		form#category-form(method="GET", action="")
 			input(type="hidden", name="sort", value=sort_mode)
-			input(type="hidden", name="limit", value=info.limit)
 			p Select category:
 				select#category(name="category", size="1", onChange='document.getElementById("category-form").submit()')
 					- void outputCat(Category cat)
@@ -61,7 +55,7 @@ block body
 					th.selected= cp[1]
 				- else
 					th
-						a(href=makeHomeURL(cp[0], category, info.skip, info.limit))= cp[1]
+						a(href="?sort=#{cp[0]}&category=#{category}")= cp[1]
 
 		- foreach (pl; info.packages)
 			- if( pl["versions"].length )
@@ -95,14 +89,7 @@ block body
 			- if (i * info.limit == info.skip)
 				li.selected= i+1
 			- else
-				li: a(href=makeHomeURL(sort_mode, category, i*info.limit, info.limit))= i+1
-	ul.pageNav.perPage
-		- static immutable limit_enum = [10, 20, 50, 100];
-		- foreach (limit; limit_enum)
-			- if (info.limit == limit)
-				li.selected= limit
-			- else
-				li: a(href=makeHomeURL(sort_mode, category, info.skip, limit))= limit
+				li: a(href="?sort=#{sort_mode}&category=#{category}&skip=#{i*info.limit}&limit=#{info.limit}")= i+1
 
 	p Displaying results #{info.skip+1} to #{min(info.skip+info.limit+1, info.packageCount)} of #{info.packageCount} packages found.
 

--- a/views/view_package.dt
+++ b/views/view_package.dt
@@ -4,6 +4,7 @@ block title
 	- import std.algorithm;
 	- import std.array : join;
 	- import vibe.data.json;
+	- import vibe.inet.url;
 	- import vibe.textfilter.urlencode;
 	- import dubregistry.viewutils;
 	- import userman.controller;
@@ -15,139 +16,166 @@ block css
 		link(rel="stylesheet", type="text/css", href="#{req.rootDir}styles/markdown.css")
 
 block body
+	.main
+		- import vibe.data.bson;
+		- if (req.session && user.id == User.ID.fromString(req.session.get!string("userID")))
+			a(href="#{req.rootDir}my_packages/#{packageName}") Manage this package
 
-	- import vibe.data.bson;
-	- if (req.session && user.id == User.ID.fromString(req.session.get!string("userID")))
-		a(href="#{req.rootDir}my_packages/#{packageName}") Manage this package
+		- if(packageName.canFind(":"))
+			- string url = req.rootDir ~ "packages/" ~ urlEncode(packageInfo["name"].get!string);
+			h1.
+				#[a.blind(href="#{url}")=packageInfo["name"].get!string]#{find(packageName, ":")} #[strong.badge #{versionInfo["version"].get!string}]
+		- else
+			h1 #{packageName} #[strong.badge #{versionInfo["version"].get!string}]
 
-	h2 Description
+		p= versionInfo["description"].opt!string
+		br
+		p To use this package, put the following dependency into your project's dependencies section:
+		.clipboard-pkg
+			- string expr = versionInfo["version"].get!string;
+			- if( !expr.startsWith("~") ) expr = "~>" ~ expr;
+			.clipboard-pkg-row
+				.clipboard-pkg-title dub.json
+				input(id="package-clipboard-json",value='"#{packageName}": "#{expr}"')
+				button(class="btn-clipboard",data-clipboard-target="#package-clipboard-json")
+					img(src="/images/clippy.svg", width=13, alt="Copy to clipboard")
 
-	p= versionInfo["description"].opt!string
-
-	h2 Package Information
-
-	- string repo_url;
-
-	table
-		- if (packageName.canFind(":"))
-			tr
-				td Root package
-				td
-					a(href='#{req.rootDir}packages/#{urlEncode(packageInfo["name"].get!string)}')= packageInfo["name"].get!string
-
-		tr
-			td Version
-			td #{versionInfo["version"].get!string} (#{formatDate(versionInfo["date"])})
-
-		- if( auto ph = "homepage" in versionInfo )
-			tr
-				td Homepage
-				td
-					a(href="#{ph.get!string}")= ph.get!string
-
-		- if( auto pr = "repository" in packageInfo )
-			- if( (*pr)["kind"] == "github" )
-				- repo_url = "https://github.com/"~(*pr)["owner"].get!string~"/"~(*pr)["project"].get!string;
-			- else if( (*pr)["kind"] == "bitbucket" )
-				- repo_url = "https://bitbucket.org/"~(*pr)["owner"].get!string~"/"~(*pr)["project"].get!string;
-			- else if( (*pr)["kind"] == "gitlab" )
-				- repo_url = "https://gitlab.com/"~(*pr)["owner"].get!string~"/"~(*pr)["project"].get!string;
-			- if (repo_url.length)
-				tr
-					td Repository
-					td
-						a(href=repo_url)= repo_url
-
-		- if( auto pl = "license" in versionInfo )
-			tr
-				td License
-				td= pl.get!string
-
-		- if( auto pl = "copyright" in versionInfo )
-			tr
-				td Copyright
-				td= pl.get!string
-
-		- if( auto pa = "authors" in versionInfo )
-			tr
-				td Authors
-				td= join(map!(a => a.get!string)(pa.get!(Json[])), ", ")
-
-		- if (user.id != User.ID.init)
-			tr
-				td Registered by
-				td= user.fullName.length ? user.fullName : user.name
+			.clipboard-pkg-row
+				.clipboard-pkg-title dub.sdl
+				input(id="package-clipboard-sdl",value='dependency "#{packageName}" version="#{expr}"')
+				button(class="btn-clipboard",data-clipboard-target="#package-clipboard-sdl")
+					img(src="/images/clippy.svg", width=13, alt="Copy to clipboard")
 
 		- if (versionInfo["subPackages"].opt!(Json[]).length)
-			tr
-				td Sub packages
-				td
-					dl
-						- foreach (sp; versionInfo["subPackages"])
-							- if (sp.type == Json.Type.object)
-								dt #{packageName}:#{sp["name"].get!string}
-								dd= sp["description"].opt!string
-							- else
-								- auto dir = sp.get!string;
-								- if (!dir.endsWith("/")) dir ~= "/";
-								dt= dir
-								dd [directory based sub package]
+			- bool helpWrited = false;
+			- foreach(sp; versionInfo["subPackages"])
+				- if(sp.type == Json.Type.object && sp["description"].opt!string)
+					- if(!helpWrited)
+						- helpWrited = true;
+						br
+						p This package provides sub packages which can be used individually:
+					p
+						- auto depname = packageName ~ ":" ~ sp["name"].get!string;
+						a.blind(href="#{req.rootDir}packages/#{urlEncode(depname)}")
+							|= depname
+						|= "- " ~ sp["description"].opt!string
 
-		tr
-			td Dependencies
-				- auto pd = "dependencies" in versionInfo;
-				- if (pd && pd.length)
-					td
-						- foreach (string dep, ver; *pd)
-							p
-								a(href="#{req.rootDir}packages/#{urlEncode(dep)}")= dep
-				- else
-					td none
+		hr
+		- if (readmeContents.length)
+			.repositoryReadme.markdown-body
+				- import vibe.textfilter.markdown : MarkdownFlags, MarkdownSettings, filterMarkdown;
+				- scope msettings = new MarkdownSettings;
+				- msettings.flags = MarkdownFlags.backtickCodeBlocks|MarkdownFlags.noInlineHtml|MarkdownFlags.tables;
+				- msettings.headingBaseLevel = 2;
+				- msettings.urlFilter = &urlFilter;
+				!= filterMarkdown(readmeContents, msettings)
+
+	.packageInfo
+		ul.unmarkedList
+			- if (user.id != User.ID.init)
+				li#registredBy Registred by #[strong= user.fullName.length ? user.fullName : user.name]
+			- if( auto pr = "repository" in packageInfo )
+				- string repo_url, repo_prefix;
+				- repo_url = (*pr)["owner"].get!string~"/"~(*pr)["project"].get!string;
+				- if( (*pr)["kind"] == "github" )
+					- repo_prefix = "https://github.com/";
+				- else if( (*pr)["kind"] == "bitbucket" )
+					- repo_prefix = "https://bitbucket.org/";
+				- if (repo_url.length)
+					li#repository
+						a.blind(href="#{repo_prefix}#{repo_url}")= repo_url
+
+			- if( auto ph = "homepage" in versionInfo )
+				- auto hpage = URL(ph.get!string);
+				li#homepage
+					a.blind(href="#{hpage.toString}")= hpage.host ~ hpage.localURI 
+
+			- if( auto pl = "license" in versionInfo )
+				li#license= pl.get!string
+
+			- if( auto pl = "copyright" in versionInfo )
+				li#copyright= pl.get!string
+
+		- if( auto pa = "authors" in versionInfo )
+			p#authors.wrap
+				strong Authors: 
+				|= join(map!(a => a.get!string)(pa.get!(Json[])), ", ")
+
+		- if (versionInfo["subPackages"].opt!(Json[]).length)
+			p#subPackages.wrap
+				strong Sub packages: 
+				- string[] subs;
+				- foreach (sp; versionInfo["subPackages"])
+					- if (sp.type == Json.Type.object)
+						- auto sub = "<span class=\"light\">" ~ packageName ~ ":</span>" ~ sp["name"].get!string;
+						- subs ~= "<a class=\"blind\" href=\"" ~ req.rootDir ~ "packages/" ~urlEncode(sub) ~ "\">" ~ sub ~ "</a>";
+					- else
+						- auto dir = sp.get!string;
+						- if (!dir.endsWith("/")) dir ~= "/";
+						- subs ~= "<a class=\"blind\" href=\"" ~ req.rootDir ~ "packages/" ~urlEncode(dir) ~ "\">" ~ dir ~ "</a>";
+				|!= join(subs, ", ")
+
+		p#dependencies.wrap
+			strong Dependencies: 
+			- auto pd = "dependencies" in versionInfo;
+			- if (pd && pd.length)
+				- string[] deps;
+				- foreach(string dep, unused; (*pd))
+					- deps ~= "<a class=\"blind\" href=\"" ~ req.rootDir ~ "packages/" ~urlEncode(dep) ~ "\">" ~ dep ~ "</a>";
+				|!= join(deps, ", ")
+			- else
+				|  none
 
 		- if (auto ps = "systemDependencies" in versionInfo)
-			tr
-				td System dependencies
-				td= ps.get!string
+			p#systemDeps.wrap
+				strong System dependencies: 
+				|= ps.get!string
 
-	h2 Installation
+		#versions
+			strong Versions:
+			- size_t counter;
+			table
+				- foreach_reverse(v; packageInfo["versions"])
+					- if(counter >= 5)
+						- break;
+					- ++counter;
+					- auto vs = v["version"].get!string;
+					tr
+						- if (vs == versionInfo["version"])
+							td
+								strong= vs
+							td
+								span= formatDate(v["date"])
+						- else
+							td
+								a.blind(href='#{req.rootDir}packages/#{urlEncode(packageName)}/#{vs}')
+									|= vs
+							td
+								span= formatDate(v["date"])
+			span#showAll
+				a.blind(href="#{req.rootDir}packages/#{urlEncode(packageName)}/versions")
+					| Show all #{packageInfo["versions"].length} versions
 
-	p To use this package, put the following dependency into your project's dependencies section:
-	- string expr = versionInfo["version"].get!string;
-	- if( !expr.startsWith("~") ) expr = "~>" ~ expr;
-
-	.clipboard-pkg
-		.clipboard-pkg-row
-			.clipboard-pkg-title dub.json
-			input(id="package-clipboard-json",value='"#{packageName}": "#{expr}"')
-			button(class="btn-clipboard",data-clipboard-target="#package-clipboard-json")
-				img(src="/images/clippy.svg", width=13, alt="Copy to clipboard")
-
-		.clipboard-pkg-row
-			.clipboard-pkg-title dub.sdl
-			input(id="package-clipboard-sdl",value='dependency "#{packageName}" version="#{expr}"')
-			button(class="btn-clipboard",data-clipboard-target="#package-clipboard-sdl")
-				img(src="/images/clippy.svg", width=13, alt="Copy to clipboard")
-
-	- if (readmeContents.length)
-		h2 Readme
-
-		.repositoryReadme.markdown-body
-			- import vibe.textfilter.markdown : MarkdownFlags, MarkdownSettings, filterMarkdown;
-			- scope msettings = new MarkdownSettings;
-			- msettings.flags = MarkdownFlags.backtickCodeBlocks|MarkdownFlags.noInlineHtml|MarkdownFlags.tables;
-			- msettings.headingBaseLevel = 2;
-			- msettings.urlFilter = &urlFilter;
-			!= filterMarkdown(readmeContents, msettings)
-
-	h2 Available versions
-
-	- foreach_reverse (v; packageInfo["versions"])
-		- auto vs = v["version"].get!string;
-		- if (vs == versionInfo["version"])
-			em= vs
-		- else
-			a(href='#{req.rootDir}packages/#{urlEncode(packageName)}/#{vs}')= vs
-		|  
+		#stats
+			- auto stats = registry.getPackageStats(packageName)["downloads"];
+			strong Stats:
+			ul.unmarkedList
+				li
+					p
+						strong= stats["daily"].to!string
+						|  downloads today
+				li
+					p
+						strong= stats["weekly"].to!string
+						|  downloads this week
+				li
+					p
+						strong= stats["monthly"].to!string
+						|  downloads this month
+				li
+					p
+						strong= stats["total"].to!string
+						|  downloads total
 
 	script(type="application/javascript", src="/scripts/clipboard.min.js")
 	:javascript

--- a/views/view_package.versions.dt
+++ b/views/view_package.versions.dt
@@ -1,0 +1,23 @@
+extends layout
+
+block title
+	- import std.conv : to;
+	- import vibe.textfilter.urlencode;
+	- import dubregistry.viewutils;
+	- auto title = "All " ~ packageInfo.versions.length.to!string ~ " versions of " ~ packageName;
+
+block css
+	link(rel="stylesheet", type="text/css", href="#{req.rootDir}styles/common.css")
+
+block body
+	h1
+		a.blind(href="#{req.rootDir}packages/#{urlEncode(packageName)}")
+			| &larr; Back to #{packageName}
+	table#versionList
+		- foreach_reverse(v; packageInfo.versions)
+			tr
+				td
+					a.blind(href="#{req.rootDir}packages/#{urlEncode(packageName)}/#{v.version_}")
+						|= v.version_
+				td
+					span= formatDate(v.date)


### PR DESCRIPTION
I wanted to add some usefull little things like download statistics or stars, but realised that there is no place where I can put them.

So, I did this:
All package information moved to sidebar at right of the screen. On the small screens (<54em) it showed at the bottom of page. Package name, description, installation instructions and readme stays at left of the screen.
Also, sidebar is grey(gray?) and contains a lot of empty space, so it won't look heavy.

Anyway, it's not done yet
## TODO
- [x] On big screens looks ugly
- [x] Link to page of all versions in `Versions:` section
- [x] 'Versions:' section should also contain date of every version (Looks like a lot of work on backend)