### PR TITLE
Let mirror mode remove packages by ID to avoid name conflicts.

### DIFF
--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -93,9 +93,21 @@ class DbController {
 		return deserializeBson!DbPackage(bpack);
 	}
 
+	DbPackage getPackage(BsonObjectID id)
+	{
+		auto bpack = m_packages.findOne(["_id": id]);
+		enforce(!bpack.isNull(), "Unknown package ID.");
+		return deserializeBson!DbPackage(bpack);
+	}
+
 	auto getAllPackages()
 	{
 		return m_packages.find(Bson.emptyObject, ["name": 1]).map!(p => p["name"].get!string)();
+	}
+
+	auto getAllPackageIDs()
+	{
+		return m_packages.find(Bson.emptyObject, ["_id": 1]).map!(p => p["_id"].get!BsonObjectID)();
 	}
 
 	auto getPackageDump()

--- a/source/dubregistry/mirror.d
+++ b/source/dubregistry/mirror.d
@@ -43,41 +43,36 @@ void mirrorRegistry(DubRegistry registry, URL url)
 nothrow {
 	logInfo("Polling '%s' for updates...", url);
 	try {
-		bool[string] current_packs;
 		auto packs = requestHTTP(url ~ Path("api/packages/dump")).readJson().deserializeJson!(DbPackage[]);
-		foreach (p; packs) {
-			current_packs[p.name] = true;
-			try setPackage(registry, p);
-			catch (Exception e) {
-				logError("Failed to add/update package '%s': %s", p.name, e.msg);
-				logDiagnostic("Full error: %s", e.toString().sanitize);
-			}
-		}
 
-		foreach (p; registry.availablePackages.array)
-			if (p !in current_packs) {
-				try removePackage(registry, p);
-				catch (Exception e) {
-					logError("Failed to remove package '%s': %s", p, e.msg);
+		bool[BsonObjectID] current_packs;
+		foreach (p; packs) current_packs[p._id] = true;
+
+		// first, remove all packages that don't exist anymore to avoid possible name conflicts
+		foreach (id; registry.availablePackageIDs)
+			if (id !in current_packs) {
+				try {
+					auto pack = registry.db.getPackage(id);
+					logInfo("Removing package '%s", pack.name);
+					registry.removePackage(pack.name, User.ID(pack.owner));
+				} catch (Exception e) {
+					logError("Failed to remove package with ID '%s': %s", id, e.msg);
 					logDiagnostic("Full error: %s", e.toString().sanitize);
 				}
 			}
 
+		// then add/update all existing packages
+		foreach (p; packs) {
+			try {
+				logInfo("Updating package '%s'", p.name);
+				registry.addOrSetPackage(p);
+			} catch (Exception e) {
+				logError("Failed to add/update package '%s': %s", p.name, e.msg);
+				logDiagnostic("Full error: %s", e.toString().sanitize);
+			}
+		}
 	} catch (Exception e) {
 		logError("Fetching updated packages failed: %s", e.msg);
 		logDiagnostic("Full error: %s", e.toString().sanitize);
 	}
-}
-
-private void setPackage(DubRegistry registry, ref DbPackage pack)
-{
-	logInfo("Updating package '%s'", pack.name);
-	registry.addOrSetPackage(pack);
-}
-
-private void removePackage(DubRegistry registry, string pack_name)
-{
-	logInfo("Removing package '%s", pack_name);
-	auto uid = registry.db.getPackage(pack_name).owner;
-	registry.removePackage(pack_name, User.ID(uid));
 }

--- a/source/dubregistry/registry.d
+++ b/source/dubregistry/registry.d
@@ -60,10 +60,8 @@ class DubRegistry {
 
 	@property DbController db() nothrow { return m_db; }
 
-	@property auto availablePackages()
-	{
-		return m_db.getAllPackages();
-	}
+	@property auto availablePackages() { return m_db.getAllPackages(); }
+	@property auto availablePackageIDs() { return m_db.getAllPackageIDs(); }
 
 	auto getPackageDump()
 	{
@@ -141,7 +139,7 @@ class DubRegistry {
 	{
 		m_db.addOrSetPackage(pack);
 		if (auto pi = pack.name in m_packageInfos)
-			*pi = getPackageInfo(pack, false);
+			m_packageInfos.remove(pack.name);
 	}
 
 	void addDownload(BsonObjectID pack_id, string ver, string agent)


### PR DESCRIPTION
It was possible that a package in the local database had a different ID than the one from the source registry. This caused the update to fail due to a name conflict. With this change, the entry with the mismatching ID is now removed first.