### PR TITLE
Use a static type for repository identifiers.

### DIFF
--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -128,7 +128,7 @@ class DbController {
 		m_packages.update(["name": packname], ["$set": ["categories": categories]]);
 	}
 
-	void setPackageRepository(string packname, Json repo)
+	void setPackageRepository(string packname, DbRepository repo)
 	{
 		m_packages.update(["name": packname], ["$set": ["repository": repo]]);
 	}
@@ -281,11 +281,17 @@ struct DbPackage {
 	BsonObjectID _id;
 	BsonObjectID owner;
 	string name;
-	Json repository;
+	DbRepository repository;
 	DbPackageVersion[] versions;
 	string[] errors;
 	string[] categories;
 	long updateCounter = 0; // used to implement lockless read-modify-write cycles
+}
+
+struct DbRepository {
+	string kind;
+	string owner;
+	string project;
 }
 
 struct DbPackageVersion {

--- a/source/dubregistry/registry.d
+++ b/source/dubregistry/registry.d
@@ -118,13 +118,13 @@ class DubRegistry {
 			Info(p.name, m_db.getVersionInfo(p.name, p.versions[$ - 1].version_)));
 	}
 
-	RepositoryInfo getRepositoryInfo(Json repository)
+	RepositoryInfo getRepositoryInfo(DbRepository repository)
 	{
 		auto rep = getRepository(repository);
 		return rep.getInfo();
 	}
 
-	void addPackage(Json repository, User.ID user)
+	void addPackage(DbRepository repository, User.ID user)
 	{
 		auto pack_name = validateRepository(repository);
 
@@ -239,7 +239,7 @@ class DubRegistry {
 		ret["owner"] = pack.owner.toString();
 		ret["name"] = pack.name;
 		ret["versions"] = Json(vers);
-		ret["repository"] = pack.repository;
+		ret["repository"] = serializeToJson(pack.repository);
 		ret["categories"] = serializeToJson(pack.categories);
 		if(include_errors) ret["errors"] = serializeToJson(pack.errors);
 		return ret;
@@ -258,7 +258,7 @@ class DubRegistry {
 		if (pack_name in m_packageInfos) m_packageInfos.remove(pack_name);
 	}
 
-	void setPackageRepository(string pack_name, Json repository)
+	void setPackageRepository(string pack_name, DbRepository repository)
 	{
 		auto new_name = validateRepository(repository);
 		enforce(pack_name == new_name, "The package name of the new repository doesn't match the existing one: "~new_name);
@@ -273,7 +273,7 @@ class DubRegistry {
 			triggerPackageUpdate(packname);
 	}
 
-	protected string validateRepository(Json repository)
+	protected string validateRepository(DbRepository repository)
 	{
 		// find the packge info of ~master or any available branch
 		PackageVersionInfo info;
@@ -437,7 +437,7 @@ class DubRegistry {
 		}
 
 		Repository rep;
-		try rep = getRepository(pack["repository"]);
+		try rep = getRepository(pack["repository"].deserializeJson!DbRepository);
 		catch( Exception e ){
 			errors ~= format("Error accessing repository: %s", e.msg);
 			logDebug("%s", sanitize(e.toString()));

--- a/source/dubregistry/repositories/bitbucket.d
+++ b/source/dubregistry/repositories/bitbucket.d
@@ -23,8 +23,8 @@ class BitbucketRepository : Repository {
 
 	static void register()
 	{
-		Repository factory(Json info){
-			return new BitbucketRepository(info["owner"].get!string, info["project"].get!string);
+		Repository factory(DbRepository info){
+			return new BitbucketRepository(info.owner, info.project);
 		}
 		addRepositoryFactory("bitbucket", &factory);
 	}

--- a/source/dubregistry/repositories/github.d
+++ b/source/dubregistry/repositories/github.d
@@ -25,8 +25,8 @@ class GithubRepository : Repository {
 
 	static void register(string user, string password)
 	{
-		Repository factory(Json info){
-			return new GithubRepository(info["owner"].get!string, info["project"].get!string, user, password);
+		Repository factory(DbRepository info){
+			return new GithubRepository(info.owner, info.project, user, password);
 		}
 		addRepositoryFactory("github", &factory);
 	}

--- a/source/dubregistry/repositories/repository.d
+++ b/source/dubregistry/repositories/repository.d
@@ -8,21 +8,21 @@ module dubregistry.repositories.repository;
 import vibe.vibe;
 
 import dubregistry.cache;
+import dubregistry.dbcontroller : DbRepository;
 import std.digest.sha;
 import std.typecons;
 
 
-Repository getRepository(Json repinfo)
+Repository getRepository(DbRepository repinfo)
 {
-	auto ident = repinfo.toString();
-	if( auto pr = ident in s_repositories )
+	if( auto pr = repinfo in s_repositories )
 		return *pr;
 
-	logDebug("Returning new repository: %s", ident);
-	auto pf = repinfo["kind"].get!string in s_repositoryFactories;
-	enforce(pf, "Unknown repository type: "~repinfo["kind"].get!string);
+	logDebug("Returning new repository: %s", repinfo);
+	auto pf = repinfo.kind in s_repositoryFactories;
+	enforce(pf, "Unknown repository type: "~repinfo.kind);
 	auto rep = (*pf)(repinfo);
-	s_repositories[ident] = rep;
+	s_repositories[repinfo] = rep;
 	return rep;
 }
 
@@ -33,7 +33,7 @@ void addRepositoryFactory(string kind, RepositoryFactory factory)
 }
 
 
-alias RepositoryFactory = Repository delegate(Json);
+alias RepositoryFactory = Repository delegate(DbRepository);
 
 interface Repository {
 	RefInfo[] getTags();
@@ -85,6 +85,6 @@ package Json readJson(string url, bool sanitize = false, bool cache_priority = f
 }
 
 private {
-	Repository[string] s_repositories;
+	Repository[DbRepository] s_repositories;
 	RepositoryFactory[string] s_repositoryFactories;
 }

--- a/source/dubregistry/web.d
+++ b/source/dubregistry/web.d
@@ -451,10 +451,10 @@ class DubRegistryFullWebFrontend : DubRegistryWebFrontend {
 	@auth @path("/register_package") @errorDisplay!getRegisterPackage
 	void postRegisterPackage(string kind, string owner, string project, User _user, bool ignore_fork = false)
 	{
-		Json rep = Json.emptyObject;
-		rep["kind"] = kind;
-		rep["owner"] = owner;
-		rep["project"] = project;
+		DbRepository rep;
+		rep.kind = kind;
+		rep.owner = owner;
+		rep.project = project;
 
 		if (!ignore_fork) {
 			auto info = m_registry.getRepositoryInfo(rep);
@@ -533,10 +533,10 @@ class DubRegistryFullWebFrontend : DubRegistryWebFrontend {
 	{
 		enforceUserPackage(_user, _packname);
 
-		Json rep = Json.emptyObject;
-		rep["kind"] = kind;
-		rep["owner"] = owner;
-		rep["project"] = project;
+		DbRepository rep;
+		rep.kind = kind;
+		rep.owner = owner;
+		rep.project = project;
 		m_registry.setPackageRepository(_packname, rep);
 
 		redirect("/my_packages/"~_packname);


### PR DESCRIPTION
The final goal is to eliminate all uses of `Json` except for package recipe contents.