### PR TITLE
Let getPackageInfo return a static type and fix access to "url".

### DIFF
--- a/source/dubregistry/api.d
+++ b/source/dubregistry/api.d
@@ -139,7 +139,8 @@ override {
 
 	Json getInfo(string name) {
 		return m_registry.getPackageInfo(rootOf(name))
-			.check!(r => r.type != Json.Type.null_)(HTTPStatus.notFound, "Package/Version not found");
+			.check!(r => r.info.type != Json.Type.null_)(HTTPStatus.notFound, "Package/Version not found")
+			.info;
 	}
 
 	Json getInfo(string name, string ver) {

--- a/views/home.dt
+++ b/views/home.dt
@@ -5,6 +5,7 @@ block title
 	- import dubregistry.web;
 	- import vibe.data.json;
 	- import std.algorithm.comparison : min;
+	- import std.algorithm.iteration : map;
 	- import std.string : replace, split;
 	- auto title = "Find, Use and Share DUB Packages";
 	script(type="application/javascript", src="scripts/home.js")
@@ -58,7 +59,8 @@ block body
 
 		- foreach (pl; info.packages)
 			- if( pl["versions"].length )
-				- auto p = getBestVersion(pl["versions"]);
+				- auto vidx = getBestVersionIndex(pl["versions"].get!(Json[]).map!(v => v["version"].opt!string));
+				- auto p = pl["versions"][vidx];
 				- auto desc = p["description"].opt!string;
 				- auto ver = p["version"].opt!string();
 				tr

--- a/views/my_packages.dt
+++ b/views/my_packages.dt
@@ -19,7 +19,7 @@ block body
 		- bool have_pack = false;
 		- foreach (p; sort!((a, b) => a < b)(registry.getPackages(user.id).array))
 			- have_pack = true;
-			- auto pack = registry.getPackageInfo(p, true);
+			- auto pack = registry.getPackageInfo(p, true).info;
 			- auto latest = pack["versions"].length ? pack["versions"][pack["versions"].length-1] : Json(null);
 			tr
 				td

--- a/views/my_packages.package.dt
+++ b/views/my_packages.package.dt
@@ -6,7 +6,7 @@ block title
 block body
 	- import vibe.data.json;
 	- import dubregistry.web : Category;
-	- auto pack = registry.getPackageInfo(packageName, true);
+	- auto pack = registry.getPackageInfo(packageName, true).info;
 
 	h2 General information
 


### PR DESCRIPTION
This makes another step into the direction of working only with static types. In particular, this also fixes the issue of accessing the non-existent JSON field "url" (removed after deprecation period), which didn't get caught because it was read from a dynamic 'Json' value.