### PR TITLE
Improve Travis setup: add ldc + botan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,6 @@
 /.dub
 /__test__library__
 /dub-registry
+/dub-registry-test-library
 *.exe
 log.txt
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,18 @@ addons:
     packages:
     - libevent-dev
     - libssl-dev
+d:
+  - dmd
+  - ldc
+
+env:
+ - VIBED_SSL=openssl
+ - VIBED_SSL=botan
+
+# Data definition directives inside inline asm are not supported yet.
+matrix:
+  allow_failures:
+      - d: ldc
+        env: VIBED_SSL=botan
+
+script: dub test --override-config="vibe-d:tls/${VIBED_SSL}"


### PR DESCRIPTION
As discussed in https://github.com/dlang/dub-registry/issues/213, this is a first step towards a better test coverage and prevention of regression.

This PR only adds the Travis framework for better testing. It doesn't add more tests and thus won't reproduce the Botan segfault. However, it does add more compilers, which are automatically updated if the script is run regularly (cron daily!) and already compiles everything with "Botan" selected.

Once this is green & merged, the next obvious step is to actually add a couple of real tests, but this is the first and simple step towards this goal.