### PR TITLE
New layout of 'Add package' page

### DIFF
--- a/public/styles/common.css
+++ b/public/styles/common.css
@@ -344,4 +344,47 @@ ul.unmarkedList > li:hover,
 	padding: 0.1em 0.3em;
 }
 
-span.light { opacity: 0.8; }
+.light { opacity: 0.8; }
+
+#registerPackage {
+	margin: 0 auto 0 0;
+	max-width: 30em;
+}
+
+#registerPackage h1 p {
+	font-size: 0.5em;
+}
+
+#registerPackage select,
+#registerPackage input {
+	box-sizing: border-box;
+	width: 100%;
+	padding: 1em;
+	border: 1px solid #ccc;
+	background-color: #fff;
+	border-radius: 2px;
+}
+
+#registerPackage label {
+	font-weight: bold;
+}
+
+#registerPackage form p {
+	margin-bottom: 1em;
+}
+
+#registerPackage button {
+	padding: 1em;
+	margin-top: 1em;
+	color: #fff;
+	background-color: #5cb85c;
+	border-color: #4cae4c;
+}
+
+.redAlert {
+	margin: 0.5em;
+	border-radius: 2px;
+	padding: 1em;
+	color: #a94442;
+	border: 1px solid #ebccd1;
+}

--- a/views/my_packages.register.dt
+++ b/views/my_packages.register.dt
@@ -4,27 +4,36 @@ block title
 	- auto title = "Add new package";
 	
 block body
-	- import std.string : splitLines;
 
-	form(method="POST", action="#{req.rootDir}register_package")
-		select(name="kind", size="1")
-			- import dubregistry.repositories.repository;
-			- if (supportsRepositoryKind("github"))
-				option(value="github", selected=kind == "github") GitHub project
-			- if (supportsRepositoryKind("bitbucket"))
-				option(value="bitbucket", selected=kind == "bitbucket") Bitbucket project
-			- if (supportsRepositoryKind("gitlab"))
-				option(value="gitlab", selected=kind == "gitlab") GitLab project
-		p
-			label(for="owner") Repository owner:
-			input(type="text", name="owner", value=owner)
-		p
-			label(for="project") Repository name:
-			input(type="text", name="project", value=project)
-		- if (error.length)
-			p.error
-				- foreach (ln; error.splitLines)
-					|= ln
-					br
-		p
-			button(type="submit") Register package
+	- if(error.length)
+		- import std.string : splitLines;
+		p.redAlert
+			- foreach (ln; error.splitLines)
+				|= ln
+				br
+
+	#registerPackage
+		h1 Add new package
+			p.light
+				a.blind(href="#{req.rootDir}publish") Learn more 
+				| about publishing.
+
+		form(method="POST", action="#{req.rootDir}register_package")
+			p
+				label(for="kind") Repository type
+				select(name="kind", size="1")
+					- import dubregistry.repositories.repository;
+					- if (supportsRepositoryKind("github"))
+						option(value="github", selected=kind == "github") GitHub project
+					- if (supportsRepositoryKind("bitbucket"))
+						option(value="bitbucket", selected=kind == "bitbucket") Bitbucket project
+					- if (supportsRepositoryKind("gitlab"))
+						option(value="gitlab", selected=kind == "gitlab") GitLab project
+			p
+				label(for="owner") Repository owner
+				input(type="text", name="owner", value=owner)
+			p
+				label(for="project") Repository name
+				input(type="text", name="project", value=project)
+			p
+				button(type="submit") Register package


### PR DESCRIPTION
This PR changes layout of the 'Add package' page. I wanted to make it mobile-friendly and clear.

### Screenshots:
![big](https://cloud.githubusercontent.com/assets/27865436/26691012/e4e8f160-46fb-11e7-9a81-bac98f6a950f.png)
![big_error](https://cloud.githubusercontent.com/assets/27865436/26691015/e50b19ac-46fb-11e7-8aa2-bab94a829ed1.png)
![small](https://cloud.githubusercontent.com/assets/27865436/26691016/e512486c-46fb-11e7-9a46-cd7f1a371a1d.png)
