### PR TITLE
package rank story

### DIFF
--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -58,6 +58,9 @@ class DbController {
 		DbPackageStats stats;
 		m_packages.update(["stats": ["$exists": false]], ["$set": ["stats": stats]], UpdateFlags.multiUpdate);
 
+		float rating = 0;
+		m_packages.update(["stats.rating": ["$exists": false]], ["$set": ["stats.rating": rating]], UpdateFlags.multiUpdate);
+
 		// create indices
 		m_packages.ensureIndex([tuple("name", 1)], IndexFlags.Unique);
 		m_downloads.ensureIndex([tuple("package", 1), tuple("version", 1)]);
@@ -305,6 +308,49 @@ class DbController {
 		return res.length ? deserializeBson!DbDownloadStats(res[0]) : DbDownloadStats.init;
 	}
 
+	DbStatDistributions getStatDistributions()
+	{
+		auto aggregate(T, string prefix, string groupBy)()
+		{
+			auto group = ["_id": Bson(groupBy ? "$"~groupBy : null)];
+			Bson[string] project;
+			foreach (mem; __traits(allMembers, T))
+			{
+				static assert(is(typeof(__traits(getMember, T.init, mem)) == DbStatDistributions.Agg));
+				static assert([__traits(allMembers, DbStatDistributions.Agg)] == ["sum", "mean", "std"]);
+				group[mem~"_sum"] = bson(["$sum": "$"~prefix~"."~mem]);
+				group[mem~"_mean"] = bson(["$avg": "$"~prefix~"."~mem]);
+				group[mem~"_std"] = bson(["$stdDevPop": "$"~prefix~"."~mem]);
+				project[mem] = bson([
+					"mean": "$"~mem~"_mean",
+					"sum": "$"~mem~"_sum",
+					"std": "$"~mem~"_std"
+				]);
+			}
+			auto res = m_packages.aggregate(["$group": group], ["$project": project]);
+
+			static if (groupBy is null)
+			{
+				if (res.length == 0)
+					return T.init;
+				assert(res.length == 1);
+				return res[0].deserializeBson!T;
+			}
+			else
+			{
+				T[string] ret;
+				foreach (doc; res)
+					ret[doc["_id"].get!string] = doc.deserializeBson!T;
+				return ret;
+			}
+		}
+
+		DbStatDistributions ret;
+		ret.downloads = aggregate!(typeof(ret.downloads), "stats.downloads", null);
+		ret.repos = aggregate!(typeof(ret.repos[""]), "stats.repo", "repository.kind");
+		return ret;
+	}
+
 	private void repairVersionOrder()
 	{
 		foreach( bp; m_packages.find() ){
@@ -372,14 +418,32 @@ struct DbPackageStats {
 	SysTime updatedAt;
 	DbDownloadStats downloads;
 	DbRepoStats repo;
+	float rating = 0; // 1-5 - higher means more relevant
+	enum minRating = 1;
+	enum maxRating = 5;
+
+	invariant
+	{
+		assert(minRating <= rating && rating <= maxRating, rating.to!string);
+	}
 }
 
-struct DbDownloadStats {
-	uint total, monthly, weekly, daily;
+struct DbDownloadStatsT(T=uint) {
+	T total, monthly, weekly, daily;
 }
 
-struct DbRepoStats {
-	uint stars, watchers, forks, issues;
+alias DbDownloadStats = DbDownloadStatsT!uint;
+
+struct DbRepoStatsT(T=uint) {
+	T stars, watchers, forks, issues;
+}
+
+alias DbRepoStats = DbRepoStatsT!uint;
+
+struct DbStatDistributions {
+	static struct Agg { ulong sum; float mean = 0, std = 0; }
+	DbDownloadStatsT!Agg downloads;
+	DbRepoStatsT!Agg[string] repos;
 }
 
 bool vcmp(DbPackageVersion a, DbPackageVersion b)

--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -418,8 +418,8 @@ struct DbPackageStats {
 	SysTime updatedAt;
 	DbDownloadStats downloads;
 	DbRepoStats repo;
-	float rating = 0; // 1-5 - higher means more relevant
-	enum minRating = 1;
+	float rating = 0; // 0 - invalid, 1-5 - higher means more relevant
+	enum minRating = 0;
 	enum maxRating = 5;
 
 	invariant

--- a/source/dubregistry/registry.d
+++ b/source/dubregistry/registry.d
@@ -160,7 +160,11 @@ class DubRegistry {
 
 		try {
 			stats.repo = getRepositoryInfo(pack.repository).stats;
-		} catch (Exception e){
+		} catch (FileNotFoundException e) {
+			// repo no longer exists, rate it down to zero (#221)
+			logInfo("Zero rating %s because the repo no longer exists.", packname);
+			stats.rating = 0;
+		} catch (Exception e) {
 			logWarn("Failed to get repository info for %s: %s", packname, e.msg);
 			return typeof(return).init;
 		}

--- a/source/dubregistry/registry.d
+++ b/source/dubregistry/registry.d
@@ -42,12 +42,18 @@ class DubRegistry {
 		PackageWorkQueue m_updateQueue;
 		// list of packages whose statistics need to be updated
 		PackageWorkQueue m_updateStatsQueue;
+		DbStatDistributions m_statDistributions;
 	}
 
 	this(DubRegistrySettings settings)
 	{
 		m_settings = settings;
 		m_db = new DbController(settings.databaseName);
+
+		// recompute ratings on startup to pick up any algorithm changes
+		m_statDistributions = m_db.getStatDistributions();
+		recomputeRatings(m_statDistributions);
+
 		m_updateQueue = new PackageWorkQueue(&updatePackage);
 		m_updateStatsQueue = new PackageWorkQueue((p) { updatePackageStats(p); });
 	}
@@ -85,9 +91,9 @@ class DubRegistry {
 
 	auto searchPackages(string query)
 	{
-		static struct Info { string name; DbPackageVersion _base; alias _base this; }
+		static struct Info { string name; DbPackageStats stats; DbPackageVersion _base; alias _base this; }
 		return m_db.searchPackages(query).filter!(p => p.versions.length > 0).map!(p =>
-			Info(p.name, m_db.getVersionInfo(p.name, p.versions[$ - 1].version_)));
+			Info(p.name, p.stats, m_db.getVersionInfo(p.name, p.versions[$ - 1].version_)));
 	}
 
 	RepositoryInfo getRepositoryInfo(DbRepository repository)
@@ -158,6 +164,11 @@ class DubRegistry {
 			logWarn("Failed to get repository info for %s: %s", packname, e.msg);
 			return typeof(return).init;
 		}
+
+		if (auto pStatDist = pack.repository.kind in m_statDistributions.repos)
+			stats.rating = computeRating(stats, m_statDistributions.downloads, *pStatDist);
+		else
+			logError("Missing stat distribution for %s repositories.", pack.repository.kind);
 
 		m_db.updatePackageStats(pack._id, stats);
 		return stats;
@@ -275,6 +286,8 @@ class DubRegistry {
 	void updatePackages()
 	{
 		logDiagnostic("Triggering package update...");
+		// update stat distributions before rating packages
+		m_statDistributions = m_db.getStatDistributions();
 		foreach (packname; this.availablePackages)
 			triggerPackageUpdate(packname);
 	}
@@ -472,6 +485,18 @@ class DubRegistry {
 
 		m_updateStatsQueue.put(packname);
 	}
+
+	/// recompute all ratings based on cached stats, e.g. after updating algorithm
+	private void recomputeRatings(DbStatDistributions dists)
+	{
+		foreach (packname; this.availablePackages)
+		{
+			const pack = m_db.getPackage(packname);
+			auto stats = m_db.getPackageStats(packname);
+			stats.rating = computeRating(stats, dists.downloads, dists.repos[pack.repository.kind]);
+			m_db.updatePackageStats(pack._id, stats);
+		}
+	}
 }
 
 private PackageVersionInfo getVersionInfo(Repository rep, RefInfo commit, string first_filename_try, Path sub_path = Path("/"))
@@ -541,4 +566,48 @@ struct PackageVersionInfo {
 struct PackageInfo {
 	PackageVersionInfo[] versions;
 	Json info; /// JSON package information, as reported to the client
+}
+
+/// Computes a package rating from given package stats and global distributions of those stats.
+private float computeRating(DownDist, RepoDist)(in ref DbPackageStats stats, DownDist downDist, RepoDist repoDist)
+{
+	import std.math : log1p, round, tanh;
+
+    if (!downDist.total.sum) // no stat distribution yet
+        return 0;
+
+	/// Using monthly downloads to penalize stale packages, logarithm to
+	/// offset exponential distribution, and tanh as smooth limiter to [0..1].
+	immutable downloadRating = tanh(log1p(stats.downloads.monthly / downDist.monthly.mean));
+	logDebug("downloadRating %s %s %s", downloadRating, stats.downloads.monthly, downDist.monthly.mean);
+
+	// Compute rating for repo
+	float sum=0, wsum=0;
+	void add(T)(float weight, float value, T dist)
+	{
+		if (dist.sum == 0)
+			return; // ignore metrics missing for that repository kind
+		sum += weight * log1p(value / dist.mean);
+		wsum += weight;
+	}
+	with (stats.repo)
+	{
+		alias d = repoDist;
+		// all of those values are highly correlated
+		add(1.0f, stars, d.stars);
+		add(1.0f, watchers, d.watchers);
+		add(1.0f, forks, d.forks);
+		add(-1.0f, issues, d.issues); // penalize many open issues/PRs
+	}
+
+	immutable repoRating = max(0.0, tanh(sum / wsum));
+	logDebug("repoRating: %s %s %s", repoRating, sum, wsum);
+
+	// average ratings
+	immutable avgRating = (repoRating + downloadRating) / 2;
+	assert(0 <= avgRating && avgRating <= 1.0, "%s %s".format(repoRating, downloadRating));
+	immutable scaled = stats.minRating + avgRating * (stats.maxRating - stats.minRating);
+	logDebug("rating: %s %s %s %s %s %s", stats.downloads.monthly, downDist.monthly.mean, downloadRating, repoRating, avgRating, scaled);
+
+	return scaled;
 }

--- a/source/dubregistry/viewutils.d
+++ b/source/dubregistry/viewutils.d
@@ -77,6 +77,17 @@ string formatFuzzyDate(SysTime st)
 	else return format("%s years ago", now.year - st.year);
 }
 
+string formatRating(float rating)
+{
+	return format("%.1f", rating);
+}
+
+string formatPackageStats(Stats)(Stats s)
+{
+	return format("%.1f\n\n#downloads / m: %s\n#stars: %s\n#watchers: %s\n#forks: %s\n#issues: %s\n",
+				  s.rating, s.downloads.monthly, s.repo.stars, s.repo.watchers, s.repo.forks, s.repo.issues);
+}
+
 /** Takes an input range of version strings and returns the index of the "best"
 	version.
 

--- a/source/dubregistry/web.d
+++ b/source/dubregistry/web.d
@@ -61,7 +61,9 @@ class DubRegistryWebFrontend {
 		import std.algorithm.iteration : filter, map;
 
 		static struct Info {
-			Json[] packages;
+			// TODO: No need to use untyped Json
+			static struct Package { DbPackageStats stats; Json _; alias _ this; }
+			Package[] packages;
 			size_t packageCount;
 			size_t skip;
 			size_t limit;
@@ -96,13 +98,14 @@ class DubRegistryWebFrontend {
 		switch (sort) {
 			default: std.algorithm.sorting.sort!compare(packages); break;
 			case "name": std.algorithm.sorting.sort!((a, b) => a.name < b.name)(packages); break;
+			case "rating": std.algorithm.sorting.sort!((a, b) => a.stats.rating > b.stats.rating)(packages); break;
 			case "added": std.algorithm.sorting.sort!((a, b) => getDateAdded(a) > getDateAdded(b))(packages); break;
 		}
 
 		Info info;
 		info.packageCount = packages.length;
 		info.packages = packages[min(skip, $) .. min(skip + limit, $)]
-			.map!(p => m_registry.getPackageInfo(p, false).info)
+			.map!(p => Info.Package(p.stats, m_registry.getPackageInfo(p, false).info))
 			.array;
 		info.skip = skip;
 		info.limit = limit;

--- a/views/home.dt
+++ b/views/home.dt
@@ -45,10 +45,12 @@ block body
 
 	table
 
-		- static immutable browse_kinds = ["name;Name", "updated;Last update", "added;Registered", ";Description"];
+		- static immutable browse_kinds = ["name;Name", "updated;Last update", "rating;Rating", "added;Registered", ";Description"];
 		tr
 			- foreach (i, c; browse_kinds)
 				- auto cp = c.split(";");
+				- if (cp[0] == "rating" && "showrating" !in req.query)
+					- continue;
 				- if (cp[0].length == 0)
 					th= cp[1]
 				- else if (sort_mode == cp[0])
@@ -78,6 +80,8 @@ block body
 						- else
 							| #{ver[0 .. 18]}&hellip;
 						span.dull.nobreak(title=formatDateTime(p["date"]))<> , #{formatFuzzyDate(p["date"])}
+					- if ("showrating" in req.query)
+						td.nobreak(title="#{formatPackageStats(pl.stats)}", style="color: #B03931;")= formatRating(pl.stats.rating)
 					td.nobreak(title=formatDateTime(pl["dateAdded"]))= formatDate(pl["dateAdded"])
 					- if (desc.length <= 100)
 						td= desc

--- a/views/search_results.dt
+++ b/views/search_results.dt
@@ -14,6 +14,8 @@ block body
 			th Package
 			th Latest version
 			th Date
+			- if ("showrating" in req.query)
+				th Rating
 			th Description
 		- foreach (p; results)
 			- auto desc = p.info["description"].opt!string;
@@ -28,6 +30,8 @@ block body
 					- else
 						| #{ver[0 .. 18]}&hellip;
 				td.nobreak= formatDate(p.date)
+				- if ("showrating" in req.query)
+					td.nobreak(title="#{formatPackageStats(p.stats)}", style="color: #B03931;")= formatRating(p.stats.rating)
 				- if (desc.length <= 100)
 					td= desc
 				- else

--- a/views/view_package.dt
+++ b/views/view_package.dt
@@ -152,26 +152,31 @@ block body
 					a.blind(href="#{req.rootDir}packages/#{urlEncode(packageName)}/versions")
 						| Show all #{packageInfo["versions"].length} versions
 
-			dt Stats:
+			- auto stats = registry.getPackageStats(packageName);
+
+			dt Download Stats:
 			dd#stats
-				- auto stats = registry.getPackageStats(packageName).downloads;
 				ul.unmarkedList
 					li
 						p
-							strong= stats.daily.to!string
+							strong= stats.downloads.daily
 							|  downloads today
 					li
 						p
-							strong= stats.weekly.to!string
+							strong= stats.downloads.weekly
 							|  downloads this week
 					li
 						p
-							strong= stats.monthly.to!string
+							strong= stats.downloads.monthly
 							|  downloads this month
 					li
 						p
-							strong= stats.total.to!string
+							strong= stats.downloads.total
 							|  downloads total
+
+			- if ("showrating" in req.query)
+				dt Rating:
+				dd#rating(title="#{formatPackageStats(stats)}")= formatRating(stats.rating)
 
 	script(type="application/javascript", src="/scripts/clipboard.min.js")
 	:javascript


### PR DESCRIPTION
- compute ranking between 0 and 5
- show ranking only with `?showranking` query parameter for now
- more stat details visible on hover (better visualization/explanation pending)
- sort search results by relevance (rounded ranking and [FTS score](https://docs.mongodb.com/manual/reference/operator/query/text/#text-operator-text-score))

![search_ranking](https://user-images.githubusercontent.com/288976/30249108-b05b285e-9634-11e7-8c00-7942206d196d.png) (mouse cursor not visible)

Commits are properly structured and should be reviewed one-by-one.

**Note for deployment:** it will take a full update cycle to populate the package stats with real data. Only on the 2nd update round (after ~30min.) we can compute the stat distributions and ratings. So initially all packages will show as equally zero rated which behaves like the status quo ;).

