### PR TITLE
Fix #229

### DIFF
--- a/views/package_format_json.dt
+++ b/views/package_format_json.dt
@@ -664,7 +664,7 @@ block body
 			td release-debug
 			td <code>["releaseMode", "optimize", "inline", "debugInfo"]</code>
 		tr
-			td release-noboundscheck
+			td release-nobounds
 			td <code>["releaseMode", "optimize", "inline", "noBoundsCheck"]</code>
 		tr
 			td unittest

--- a/views/package_format_sdl.dt
+++ b/views/package_format_sdl.dt
@@ -634,7 +634,7 @@ block body
 			td release-debug
 			td <code>"releaseMode" "optimize" "inline" "debugInfo"</code>
 		tr
-			td release-noboundscheck
+			td release-nobounds
 			td <code>"releaseMode" "optimize" "inline" "noBoundsCheck"</code>
 		tr
 			td unittest


### PR DESCRIPTION
Fixes build type `release-nobounds` as defined [here](https://github.com/dlang/dub/blob/master/source/dub/package_.d#L405).