### PR TITLE
New layout of the 'reset password' page

### DIFF
--- a/views/userman.forgot_login.dt
+++ b/views/userman.forgot_login.dt
@@ -1,0 +1,22 @@
+extends layout
+
+block title
+	- auto title = "Reset your password";
+
+block body
+	- if(error.length)
+		- import std.string : splitLines;
+		p.redAlert
+			- foreach (ln; error.splitLines)
+				|= ln
+				br
+
+	.inputForm
+		h1 Reset your password
+			p.light Please enter your email address below to have an email sent to you containing your user name and a link to reset your password.
+		form(method="POST", action="forgot_login")
+			p
+				label(for="email") Email:
+				input(type="email", name="email")
+			p
+				button(type="submit") Request password reset


### PR DESCRIPTION
Changes layout of the 'reset password' page

Screenshots:
![forgot](https://user-images.githubusercontent.com/27865436/28412596-01fb3b54-6d45-11e7-8581-25e82b6365da.png)
![forgot_error](https://user-images.githubusercontent.com/27865436/28412597-02185586-6d45-11e7-8bc8-0ba6f9431948.png)
