### PR TITLE
Fix labels issue in Firefox

### DIFF
--- a/public/styles/common.css
+++ b/public/styles/common.css
@@ -354,6 +354,7 @@ ul.unmarkedList > li:hover,
 .inputForm {
 	margin: 0 auto 0 0;
 	max-width: 30em;
+	text-align: left;
 }
 
 .inputForm h1 p {


### PR DESCRIPTION
Fixes this:
![fixff](https://user-images.githubusercontent.com/27865436/29262420-c6049d22-80d4-11e7-8404-1c269107a2f3.png)

Works for all input forms with `.inputForm` class.