### PR TITLE
improve styling for package info

### DIFF
--- a/public/styles/common.css
+++ b/public/styles/common.css
@@ -285,7 +285,6 @@ div#versions > p {
 	margin-bottom: 0.5em !important;
 }
 
-div.packageInfo > *,
 ul.unmarkedList > li {
 	white-space: nowrap;
 	overflow: hidden;
@@ -317,10 +316,26 @@ ul.unmarkedList > li:hover,
 	white-space: nowrap;
 }
 
+div.packageInfo > dl > dt {
+	font-weight: bold;
+}
+
+div.packageInfo > dl > dt:not(:first-child) {
+	padding-top: 0.5em;
+}
+
+div.packageInfo > dl > dd {
+	padding: 0.25em 0 0.25em 0.5em;
+	margin: 0;
+}
+
 #stats ul li {
 	line-height: 1em;
 	border-style: none;
 	margin-bottom: 0;
+}
+#stats ul {
+	margin: 0;
 }
 
 #versions strong {
@@ -329,7 +344,7 @@ ul.unmarkedList > li:hover,
 #versions table,
 #showAll{
 	line-height: 1em;
-	margin: 0 2em;
+	margin: 0;
 	font-family: monospace;
 }
 

--- a/views/view_package.dt
+++ b/views/view_package.dt
@@ -96,82 +96,81 @@ block body
 			- if( auto pl = "copyright" in versionInfo )
 				li#copyright= pl.get!string
 
-		- if( auto pa = "authors" in versionInfo )
-			p#authors.wrap
-				strong Authors:
-				|= join(map!(a => a.get!string)(pa.get!(Json[])), ", ")
+		dl
+			- if( auto pa = "authors" in versionInfo )
+				dt Authors:
+				dd.wrap= join(map!(a => a.get!string)(pa.get!(Json[])), ", ")
 
-		- if (versionInfo["subPackages"].opt!(Json[]).length)
-			p#subPackages.wrap
-				strong Sub packages:
-				- string[] subs;
-				- foreach (sp; versionInfo["subPackages"])
-					- auto name = sp["name"].get!string;
-					- auto sub = "<span class=\"light\">" ~ packageName ~ ":</span>" ~ name;
-					- subs ~= "<a class=\"blind\" href=\"" ~ req.rootDir ~ "packages/" ~urlEncode(packageName ~ ":" ~ name) ~ "\">" ~ sub ~ "</a>";
-				|!= join(subs, ", ")
+			- if (versionInfo["subPackages"].opt!(Json[]).length)
+				dt Sub packages:
+				dd.wrap
+					- string[] subs;
+					- foreach (sp; versionInfo["subPackages"])
+						- auto name = sp["name"].get!string;
+						- auto sub = "<span class=\"light\">" ~ packageName ~ ":</span>" ~ name;
+						- subs ~= "<a class=\"blind\" href=\"" ~ req.rootDir ~ "packages/" ~urlEncode(packageName ~ ":" ~ name) ~ "\">" ~ sub ~ "</a>";
+					|!= join(subs, ", ")
 
-		p#dependencies.wrap
-			strong Dependencies:
-			- auto pd = "dependencies" in versionInfo;
-			- if (pd && pd.length)
-				- string[] deps;
-				- foreach(string dep, unused; (*pd))
-					- deps ~= "<a class=\"blind\" href=\"" ~ req.rootDir ~ "packages/" ~urlEncode(dep) ~ "\">" ~ dep ~ "</a>";
-				|!= join(deps, ", ")
-			- else
-				|  none
+			dt Dependencies:
+			dd.wrap
+				- auto pd = "dependencies" in versionInfo;
+				- if (pd && pd.length)
+					- string[] deps;
+					- foreach(string dep, unused; (*pd))
+						- deps ~= "<a class=\"blind\" href=\"" ~ req.rootDir ~ "packages/" ~urlEncode(dep) ~ "\">" ~ dep ~ "</a>";
+					|!= join(deps, ", ")
+				- else
+					|  none
 
-		- if (auto ps = "systemDependencies" in versionInfo)
-			p#systemDeps.wrap
-				strong System dependencies:
-				|= ps.get!string
+			- if (auto ps = "systemDependencies" in versionInfo)
+				dt System dependencies:
+				dd.wrap= ps.get!string
 
-		#versions
-			strong Versions:
-			- size_t counter;
-			table
-				- foreach_reverse(v; packageInfo["versions"])
-					- if(counter >= 5)
-						- break;
-					- ++counter;
-					- auto vs = v["version"].get!string;
-					tr
-						- if (vs == versionInfo["version"])
-							td
-								strong= vs
-							td
-								span= formatDate(v["date"])
-						- else
-							td
-								a.blind(href='#{req.rootDir}packages/#{urlEncode(packageName)}/#{vs}')
-									|= vs
-							td
-								span= formatDate(v["date"])
-			span#showAll
-				a.blind(href="#{req.rootDir}packages/#{urlEncode(packageName)}/versions")
-					| Show all #{packageInfo["versions"].length} versions
+			dt Versions:
+			dd#versions
+				- size_t counter;
+				table
+					- foreach_reverse(v; packageInfo["versions"])
+						- if(counter >= 5)
+							- break;
+						- ++counter;
+						- auto vs = v["version"].get!string;
+						tr
+							- if (vs == versionInfo["version"])
+								td
+									strong= vs
+								td
+									span= formatDate(v["date"])
+							- else
+								td
+									a.blind(href='#{req.rootDir}packages/#{urlEncode(packageName)}/#{vs}')
+										|= vs
+								td
+									span= formatDate(v["date"])
+				span#showAll
+					a.blind(href="#{req.rootDir}packages/#{urlEncode(packageName)}/versions")
+						| Show all #{packageInfo["versions"].length} versions
 
-		#stats
-			- auto stats = registry.getPackageStats(packageName).downloads;
-			strong Stats:
-			ul.unmarkedList
-				li
-					p
-						strong= stats.daily.to!string
-						|  downloads today
-				li
-					p
-						strong= stats.weekly.to!string
-						|  downloads this week
-				li
-					p
-						strong= stats.monthly.to!string
-						|  downloads this month
-				li
-					p
-						strong= stats.total.to!string
-						|  downloads total
+			dt Stats:
+			dd#stats
+				- auto stats = registry.getPackageStats(packageName).downloads;
+				ul.unmarkedList
+					li
+						p
+							strong= stats.daily.to!string
+							|  downloads today
+					li
+						p
+							strong= stats.weekly.to!string
+							|  downloads this week
+					li
+						p
+							strong= stats.monthly.to!string
+							|  downloads this month
+					li
+						p
+							strong= stats.total.to!string
+							|  downloads total
 
 	script(type="application/javascript", src="/scripts/clipboard.min.js")
 	:javascript


### PR DESCRIPTION
- use definition list for named sections and add a bit of spacing
- align all entries to 0.5em padding

### old
![package_info_old](https://user-images.githubusercontent.com/288976/29528346-001358d8-869c-11e7-88bd-24c205888945.png)
### new
![package_info_new](https://user-images.githubusercontent.com/288976/29529414-db930554-869f-11e7-9b18-aa1225fc0a62.png)
