### PR TITLE
Fix "Remove this package" button

### DIFF
--- a/public/styles/common.css
+++ b/public/styles/common.css
@@ -210,14 +210,6 @@ button {
     cursor: pointer;
 }
 
-button.danger {
-	background-color: #943029;
-	border-color: #872c25;
-	padding: 0.5em;
-	margin-top: 0.5em;
-	color: #fff;
-}
-
 /*********************/
 /* PACKAGE CLIPBOARD */
 /*********************/
@@ -408,6 +400,13 @@ div.packageInfo > dl > dd {
 	color: #fff;
 	background-color: #5cb85c;
 	border-color: #4cae4c;
+}
+
+.inputForm button.danger {
+	background-color: #943029;
+	border-color: #872c25;
+	padding: 0.5em;
+	margin-top: 0.5em;
 }
 
 .redAlert {


### PR DESCRIPTION
Makes "Remove this package" button smaller and paints it red, as intended in #245.

![fixbutton](https://user-images.githubusercontent.com/27865436/29785496-25c77398-8c28-11e7-8a1a-9b678d1a1e06.png)
