### PR TITLE
[trivial] Fix the information about Arch Linux packages.

### DIFF
--- a/views/download.dt
+++ b/views/download.dt
@@ -5,7 +5,7 @@ block title
 	- import dubregistry.viewutils;
 	- import std.algorithm : sort;
 	- auto title = "Download";
-	
+
 block body
 
 	h2 Precompiled binaries
@@ -44,11 +44,11 @@ block body
 
 
 	h2 System packages and manual build
-	
+
 	:markdown
 		If your platform is not supported, building is as easy as checking out the [git repository](https://github.com/rejectedsoftware/dub) and running `./build.sh`. You need to have the development version of libcurl with SSL support installed. The resulting binary can then optionally be made available in `PATH`.
 
-		For Arch Linux, Mihail Strašun maintains a community package ([dub i386](https://www.archlinux.org/packages/community/i686/dub/)/[dub amd64](https://www.archlinux.org/packages/community/x86_64/dub/)) and Moritz Maxeiner maintains an AUR package for GIT master ([dub-git](https://aur.archlinux.org/packages/dub-git)).
+		For Arch Linux, AUR packages exist for the latest release ([dub](https://aur.archlinux.org/packages/dub/)), GIT master ([dub-git](https://aur.archlinux.org/packages/dub-git)), and for ARM ([dub-arm](https://aur.archlinux.org/packages/dub-arm/)).
 
 		Debian packages are available as part of Jordi Sayol's [D APT repository](http://d-apt.sourceforge.net/). Use `apt-get install dub`.
 


### PR DESCRIPTION
When @dicebot stepped down as the package maintainer, the community packages were dropped and replaced by an AUR package.