### PR TITLE
Compute statistics updates in a queue parallel to the general update queue.

### DIFF
--- a/source/dubregistry/internal/workqueue.d
+++ b/source/dubregistry/internal/workqueue.d
@@ -1,0 +1,134 @@
+/**
+	Copyright: © 2017 rejectedsoftware e.K.
+	License: Subject to the terms of the GNU GPLv3 license, as written in the included LICENSE.txt file.
+	Authors: Sönke Ludwig
+*/
+module dubregistry.internal.workqueue;
+
+import std.algorithm.searching : canFind, countUntil;
+import std.datetime : Clock, SysTime, UTC, msecs, hours;
+import std.encoding : sanitize;
+import vibe.core.core;
+import vibe.core.log;
+import vibe.core.sync;
+import vibe.utils.array : FixedRingBuffer;
+
+final class PackageWorkQueue {
+	private {
+		FixedRingBuffer!string m_queue;
+		string m_current;
+		Task m_task;
+		TaskMutex m_mutex;
+		TaskCondition m_condition;
+		void delegate(string) m_handler;
+		SysTime m_lastSignOfLifeOfUpdateTask;
+	}
+
+	this(void delegate(string) handler)
+	{
+		m_handler = handler;
+		m_queue.capacity = 10000;
+		m_mutex = new TaskMutex;
+		m_condition = new TaskCondition(m_mutex);
+		m_task = runTask(&processQueue);
+	}
+
+	bool isPending(string pack_name)
+	{
+		return getPosition(pack_name) >= 0;
+	}
+
+	sizediff_t getPosition(string pack_name)
+	{
+		if (m_current == pack_name) return 0;
+		synchronized (m_mutex) {
+			auto idx = m_queue[].countUntil(pack_name);
+			return idx >= 0 ? idx + 1 : -1;
+		}
+	}
+
+	void put(string pack_name)
+	{
+		synchronized (m_mutex) {
+			if (!m_queue[].canFind(pack_name))
+				m_queue.put(pack_name);
+		}
+
+		// watchdog for update task
+		if (m_task.running && Clock.currTime(UTC()) - m_lastSignOfLifeOfUpdateTask > 2.hours) {
+			logError("Update task has hung. Trying to interrupt.");
+			m_task.interrupt();
+		}
+
+		if (!m_task.running)
+			m_task = runTask(&processQueue);
+		m_condition.notifyAll();
+	}
+
+	private void processQueue()
+	{
+		scope (exit) logWarn("Update task was killed!");
+		while (true) {
+			m_lastSignOfLifeOfUpdateTask = Clock.currTime(UTC());
+			logDiagnostic("Getting new package to be updated...");
+			string pack;
+			synchronized (m_mutex) {
+				while (m_queue.empty) {
+					logDiagnostic("Waiting for package to be updated...");
+					m_condition.wait();
+				}
+				pack = m_queue.front;
+				m_queue.popFront();
+				m_current = pack;
+			}
+			scope(exit) m_current = null;
+			logDiagnostic("Processing package %s.", pack);
+			try m_handler(pack);
+			catch (Exception e) {
+				logWarn("Failed to handle package %s: %s", pack, e.msg);
+				logDiagnostic("Full error: %s", e.toString().sanitize);
+			}
+		}
+	}
+}
+
+unittest {
+	size_t done = false;
+	string expected;
+	size_t cnt = 0;
+
+	void handler(string pack)
+	{
+		assert(pack == expected);
+		cnt++;
+		sleep(100.msecs);
+	}
+
+	void test()
+	{
+		auto q = new PackageWorkQueue(&handler);
+		assert(!q.isPending("foo"));
+		assert(!q.isPending("bar"));
+		assert(q.getPosition("foo") < 0);
+		expected = "foo";
+		q.put("foo");
+		q.put("bar");
+		assert(q.isPending("foo"));
+		assert(q.isPending("bar"));
+		assert(q.getPosition("bar") == q.getPosition("foo") + 1);
+		yield();
+		assert(q.getPosition("foo") == 0);
+		assert(q.getPosition("bar") == 1);
+		expected = "bar";
+		sleep(300.msecs);
+		assert(!q.isPending("foo"));
+		assert(!q.isPending("bar"));
+		assert(cnt == 2);
+		done = true;
+		exitEventLoop();
+	}
+
+	runTask(&test);
+	runEventLoop();
+	assert(done, "Test was skipped!?");
+}

--- a/source/dubregistry/registry.d
+++ b/source/dubregistry/registry.d
@@ -7,6 +7,7 @@ module dubregistry.registry;
 
 import dubregistry.cache : FileNotFoundException;
 import dubregistry.dbcontroller;
+import dubregistry.internal.workqueue;
 import dubregistry.repositories.repository;
 
 import dub.semver;
@@ -25,7 +26,6 @@ import vibe.core.log;
 import vibe.data.bson;
 import vibe.data.json;
 import vibe.stream.operations;
-import vibe.utils.array : FixedRingBuffer;
 
 
 /// Settings to configure the package registry.
@@ -39,22 +39,14 @@ class DubRegistry {
 		DbController m_db;
 
 		// list of package names to check for updates
-		FixedRingBuffer!string m_updateQueue;
-		string m_currentUpdatePackage;
-		Task m_updateQueueTask;
-		TaskMutex m_updateQueueMutex;
-		TaskCondition m_updateQueueCondition;
-		SysTime m_lastSignOfLifeOfUpdateTask;
+		PackageWorkQueue m_updateQueue;
 	}
 
 	this(DubRegistrySettings settings)
 	{
 		m_settings = settings;
 		m_db = new DbController(settings.databaseName);
-		m_updateQueue.capacity = 10000;
-		m_updateQueueMutex = new TaskMutex;
-		m_updateQueueCondition = new TaskCondition(m_updateQueueMutex);
-		m_updateQueueTask = runTask(&processUpdateQueue);
+		m_updateQueue = new PackageWorkQueue(&updatePackage);
 	}
 
 	@property DbController db() nothrow { return m_db; }
@@ -69,28 +61,12 @@ class DubRegistry {
 
 	void triggerPackageUpdate(string pack_name)
 	{
-		synchronized (m_updateQueueMutex) {
-			if (!m_updateQueue[].canFind(pack_name))
-				m_updateQueue.put(pack_name);
-		}
-
-		// watchdog for update task
-		if (Clock.currTime(UTC()) - m_lastSignOfLifeOfUpdateTask > 2.hours) {
-			logError("Update task has hung. Trying to interrupt.");
-			m_updateQueueTask.interrupt();
-		}
-
-		if (!m_updateQueueTask.running)
-			m_updateQueueTask = runTask(&processUpdateQueue);
-		m_updateQueueCondition.notifyAll();
+		m_updateQueue.put(pack_name);
 	}
 
 	bool isPackageScheduledForUpdate(string pack_name)
 	{
-		if (m_currentUpdatePackage == pack_name) return true;
-		synchronized (m_updateQueueMutex)
-			if (m_updateQueue[].canFind(pack_name)) return true;
-		return false;
+		return m_updateQueue.isPending(pack_name);
 	}
 
 	/** Returns the current index of a given package in the update queue.
@@ -101,11 +77,7 @@ class DubRegistry {
 	*/
 	sizediff_t getUpdateQueuePosition(string pack_name)
 	{
-		if (m_currentUpdatePackage == pack_name) return 0;
-		synchronized (m_updateQueueMutex) {
-			auto idx = m_updateQueue[].countUntil(pack_name);
-			return idx >= 0 ? idx + 1 : -1;
-		}
+		return m_updateQueue.getPosition(pack_name);
 	}
 
 	auto searchPackages(string query)
@@ -420,32 +392,6 @@ class DubRegistry {
 		assert(ver.startsWith("~") && !ver.startsWith("~~") || isValidVersion(ver));
 
 		m_db.removeVersion(packname, ver);
-	}
-
-	private void processUpdateQueue()
-	{
-		scope (exit) logWarn("Update task was killed!");
-		while (true) {
-			m_lastSignOfLifeOfUpdateTask = Clock.currTime(UTC());
-			logDiagnostic("Getting new package to be updated...");
-			string pack;
-			synchronized (m_updateQueueMutex) {
-				while (m_updateQueue.empty) {
-					logDiagnostic("Waiting for package to be updated...");
-					m_updateQueueCondition.wait();
-				}
-				pack = m_updateQueue.front;
-				m_updateQueue.popFront();
-				m_currentUpdatePackage = pack;
-			}
-			scope(exit) m_currentUpdatePackage = null;
-			logDiagnostic("Updating package %s.", pack);
-			try updatePackage(pack);
-			catch (Exception e) {
-				logWarn("Failed to check versions for %s: %s", pack, e.msg);
-				logDiagnostic("Full error: %s", e.toString().sanitize);
-			}
-		}
 	}
 
 	private void updatePackage(string packname)

--- a/source/dubregistry/registry.d
+++ b/source/dubregistry/registry.d
@@ -40,6 +40,8 @@ class DubRegistry {
 
 		// list of package names to check for updates
 		PackageWorkQueue m_updateQueue;
+		// list of packages whose statistics need to be updated
+		PackageWorkQueue m_updateStatsQueue;
 	}
 
 	this(DubRegistrySettings settings)
@@ -47,6 +49,7 @@ class DubRegistry {
 		m_settings = settings;
 		m_db = new DbController(settings.databaseName);
 		m_updateQueue = new PackageWorkQueue(&updatePackage);
+		m_updateStatsQueue = new PackageWorkQueue((p) { updatePackageStats(p); });
 	}
 
 	@property DbController db() nothrow { return m_db; }
@@ -467,7 +470,7 @@ class DubRegistry {
 		}
 		m_db.setPackageErrors(packname, errors);
 
-		updatePackageStats(packname);
+		m_updateStatsQueue.put(packname);
 	}
 }
 


### PR DESCRIPTION
While the update queue is mostly API performance dependent, the statistics updates are mostly DB query performance dependent. Computing them in sequence resulted in a serious decline in package update check performance. With this change, statistics updates should have almost no impact on the update speed. If they turn out to be slower than the updates, they will simply be updated as fast as possible in a round-robin fashion.