### PR TITLE
Fix anchor link in README.md when viewing package info

### DIFF
--- a/source/dubregistry/web.d
+++ b/source/dubregistry/web.d
@@ -210,7 +210,7 @@ class DubRegistryWebFrontend {
 						// TODO: BitBucket + GitLab
 						case "github":
 							if (is_image) return format("https://github.com/%s/%s/raw/%s/%s", owner, project, gitVer, url);
-							else return format("https://github.com/%s/%s/blob/%s/%s", owner, project, gitVer, url);
+							else return format("https://github.com/%s/%s/blob/%s/%s", owner, project, gitVer, url.startsWith("#") ? "README.md" ~ url : url);
 					}
 				}
 


### PR DESCRIPTION
If the url is `#foobar` (an anchor link), the blob file should be `README.md`