### PR TITLE
[trivial] Style disabled buttons gray and with no "hand" mouse cursor.

### DIFF
--- a/public/styles/common.css
+++ b/public/styles/common.css
@@ -412,6 +412,12 @@ div.packageInfo > dl > dd {
 	border-color: #4cae4c;
 }
 
+.inputForm button:disabled {
+	background-color: #888;
+	border-color: #666;
+	cursor: default;
+}
+
 .inputForm button.danger {
 	background-color: #943029;
 	border-color: #872c25;


### PR DESCRIPTION
In particular makes the update section look like this instead of having a green button:
![image](https://user-images.githubusercontent.com/1645969/30485338-5e80b312-9a2d-11e7-98e1-6c5fcfe54c3e.png)
