### PR TITLE
Mention dub using pkg-config in the package file format documentations

### DIFF
--- a/views/package_format_json.dt
+++ b/views/package_format_json.dt
@@ -276,7 +276,7 @@ block body
 		tr
 			td libs
 			td: code string[]
-			td A list of external library names - depending on the compiler, these will be converted to the proper linker flag (e.g. "ssl" might get translated to "-L-lssl")
+			td A list of external library names - depending on the compiler, these will be converted to the proper linker flag (e.g. "ssl" might get translated to "-L-lssl"). On Posix platforms dub will try to find the correct linker flags by using <a href="https://www.freedesktop.org/wiki/Software/pkg-config/">pkg-config</a>
 
 		tr
 			td sourceFiles

--- a/views/package_format_sdl.dt
+++ b/views/package_format_sdl.dt
@@ -250,7 +250,7 @@ block body
 		tr
 			td libs
 			td: code "&lt;lib1&gt;" ["&lt;lib2&gt;" [...]]
-			td A list of external library names - depending on the compiler, these will be converted to the proper linker flag (e.g. "ssl" might get translated to "-L-lssl")
+			td A list of external library names - depending on the compiler, these will be converted to the proper linker flag (e.g. "ssl" might get translated to "-L-lssl"). On Posix platforms dub will try to find the correct linker flags by using <a href="https://www.freedesktop.org/wiki/Software/pkg-config/">pkg-config</a>
 
 		tr
 			td sourceFiles


### PR DESCRIPTION
The documentation didn't mention that pkg-config is used on Posix platforms to resolve linker flags for libraries specified in the "libs" field of the package config file