### PR TITLE
Package creation input convenience

### DIFF
--- a/public/styles/common.css
+++ b/public/styles/common.css
@@ -69,7 +69,7 @@ p > span.repoError {
 	display: none;
 }
 
-p > input:invalid + span.repoError, p > span.repoError.visible {
+p > input:invalid + span.repoError {
 	display: block;
 }
 

--- a/public/styles/common.css
+++ b/public/styles/common.css
@@ -64,6 +64,15 @@ p.error, li.error, span.error {
 	color: red;
 }
 
+p > span.repoError {
+	color: red;
+	display: none;
+}
+
+p > input:invalid + span.repoError, p > span.repoError.visible {
+	display: block;
+}
+
 p.warn {
 	color: #ffa000;
 }

--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -490,7 +490,7 @@ struct DbRepository {
 		auto path = url.path.bySegment;
 		if (path.empty)
 			throw new Exception("Invalid Repository URL (no path)");
-		assert(path.front.name.empty); // first element is empty
+		assert(path.front.name.empty, "got non-empty first segment in URL (before root)");
 		path.popFront;
 		if (path.empty || path.front.name.empty)
 			throw new Exception("Invalid Repository URL (missing owner)");

--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -473,6 +473,36 @@ struct DbRepository {
 	string kind;
 	string owner;
 	string project;
+
+	void parseURL(URL url) {
+		string host = url.host;
+		if (!url.schema.among!("http", "https"))
+			throw new Exception("Invalid Repository Schema (only supports http and https)");
+		if (host.endsWith(".github.com") || host == "github.com" || host == "github") {
+			kind = "github";
+		} else if (host.endsWith(".gitlab.com") || host == "gitlab.com" || host == "gitlab") {
+			kind = "bitbucket";
+		} else if (host.endsWith(".bitbucket.org") || host == "bitbucket.org" || host == "bitbucket") {
+			kind = "gitlab";
+		} else {
+			throw new Exception("Please input a valid project URL to a GitHub, GitLab or BitBucket project.");
+		}
+		auto path = url.path.bySegment;
+		if (path.empty)
+			throw new Exception("Invalid Repository URL (no path)");
+		assert(path.front.name.empty); // first element is empty
+		path.popFront;
+		if (path.empty || path.front.name.empty)
+			throw new Exception("Invalid Repository URL (missing owner)");
+		owner = path.front.name;
+		path.popFront;
+		if (path.empty || path.front.name.empty)
+			throw new Exception("Invalid Repository URL (missing project)");
+		project = path.front.name;
+		path.popFront;
+		if (!path.empty)
+			throw new Exception("Invalid Repository URL (got more than owner and project)");
+	}
 }
 
 struct DbPackageFile {

--- a/source/dubregistry/web.d
+++ b/source/dubregistry/web.d
@@ -521,21 +521,25 @@ class DubRegistryFullWebFrontend : DubRegistryWebFrontend {
 	}
 
 	@auth @path("/register_package")
-	void getRegisterPackage(User _user, string kind = null, string owner = null, string project = null, string _error = null)
+	void getRegisterPackage(User _user, string url = null, string _error = null)
 	{
 		auto user = _user;
 		string error = _error;
 		auto registry = m_registry;
-		render!("my_packages.register.dt", user, kind, owner, project, error, registry);
+		render!("my_packages.register.dt", user, url, error, registry);
 	}
 
 	@auth @path("/register_package") @errorDisplay!getRegisterPackage
-	void postRegisterPackage(string kind, string owner, string project, User _user, bool ignore_fork = false)
+	void postRegisterPackage(string url, User _user, bool ignore_fork = false)
 	{
 		DbRepository rep;
-		rep.kind = kind;
-		rep.owner = owner;
-		rep.project = project;
+		if (!url.canFind("://"))
+			url = "https://" ~ url;
+		rep.parseURL(URL.fromString(url));
+
+		string kind = rep.kind;
+		string owner = rep.owner;
+		string project = rep.project;
 
 		if (!ignore_fork) {
 			auto info = m_registry.getRepositoryInfo(rep);

--- a/views/my_packages.register.dt
+++ b/views/my_packages.register.dt
@@ -20,20 +20,8 @@ block body
 
 		form(method="POST", action="#{req.rootDir}register_package")
 			p
-				label(for="kind") Repository type
-				select(name="kind", size="1")
-					- import dubregistry.repositories.repository;
-					- if (supportsRepositoryKind("github"))
-						option(value="github", selected=kind == "github") GitHub project
-					- if (supportsRepositoryKind("bitbucket"))
-						option(value="bitbucket", selected=kind == "bitbucket") Bitbucket project
-					- if (supportsRepositoryKind("gitlab"))
-						option(value="gitlab", selected=kind == "gitlab") GitLab project
-			p
-				label(for="owner") Repository owner
-				input(type="text", name="owner", value=owner)
-			p
-				label(for="project") Repository name
-				input(type="text", name="project", value=project)
+				label(for="project") Repository URL
+				input(type="text", name="url", value=url, pattern="^(https?://)?(www\.)?(github(\.com)?|gitlab(\.com)?|bitbucket(\.org)?)/[^/]+/[^/]+([?#.].*)?$", placeholder="github.com/user/repository")
+				span.repoError Please enter a valid project URL or tuple to a GitHub, GitLab or BitBucket project, such as #[code https://gitlab.com/dlang/dub] or #[code bitbucket/dlang/dub].
 			p
 				button(type="submit") Register package


### PR DESCRIPTION
When creating a package and pasting a URL or repository creator + name it fills out the information automatically now.

Accepted formats:

```
dlang/dub
http(s)://(www.)github.com/dlang/dub
http(s)://(www.)gitlab.com/foo/bar
http(s)://(www.)bitbucket.org/foo/bar
```