### PR TITLE
Add <package>.dub.pm shorturls to the package overview

### DIFF
--- a/views/view_package.dt
+++ b/views/view_package.dt
@@ -177,6 +177,10 @@ block body
 			dt Score:
 			dd#score(title="#{formatPackageStats(stats)}")!= formatScore(req.rootDir, stats.score)
 
+			dt Short URL:
+				dd
+					a(href="http://#{packageName}.dub.pm", target="_blank") #{packageName}.dub.pm
+
 	script(type="application/javascript", src="/scripts/clipboard.min.js")
 	:javascript
 		new Clipboard('.btn-clipboard');


### PR DESCRIPTION
Preview:

![image](https://user-images.githubusercontent.com/4370550/35632529-3aad036e-06a7-11e8-983a-760acc64ad8c.png)

(FWIW the dub registry doesn't work well with mongo 3.6 - I had to disable the stats aggregation locally for now.)