### PR TITLE
Specify foreground color for inputs

### DIFF
--- a/public/styles/common.css
+++ b/public/styles/common.css
@@ -409,6 +409,7 @@ div.packageInfo > dl > dd {
 	padding: 1em;
 	border: 1px solid #ccc;
 	background-color: #fff;
+	color: #000;
 	border-radius: 2px;
 }
 


### PR DESCRIPTION
Don't set the background color without setting the foreground color. For dark themes the text could be white by default.