### PR TITLE
Remove mdondorff from authors

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -1,7 +1,7 @@
 name "dub-registry"
 description "Online registry for dub packages"
 homepage "http://code.dlang.org/"
-authors "Sönke Ludwig" "Matthias Dondorff"
+authors "Sönke Ludwig"
 license "GPL-3.0"
 
 dependency "vibe-d" version="~>0.8.3-alpha"


### PR DESCRIPTION
I haven't been doing any noteworthy thing for dub-registry, hence removing myself from the 'Authors' section.