### PR TITLE
Only store data necessary for sorting the package list in memory.

### DIFF
--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -131,6 +131,11 @@ class DbController {
 		return pack;
 	}
 
+	auto getPackages(scope string[] packnames...)
+	{
+		return m_packages.find!DbPackage(["name": ["$in": serializeToBson(packnames)]]);
+	}
+
 	BsonObjectID getPackageID(string packname)
 	{
 		static struct PID { BsonObjectID _id; }

--- a/source/dubregistry/registry.d
+++ b/source/dubregistry/registry.d
@@ -215,12 +215,18 @@ class DubRegistry {
 
 	/** Gets information about multiple packages at once.
 
-		The order of the returned packages is undefined and some of the package
-		names may not result in a `PackageInfo` to be returned at all, if no
-		package with the given name exists, so that the returned range needs
-		to be manually matched against the list of names.
+		The order and count of packages returned may not correspond to the list
+		of supplied package names. Only those packages that actually reference
+		an existing package will yield a result element.
+
+		The consequence is that the caller must manually match the result to
+		the supplied package names.
 
 		This function requires only a single query to the database.
+
+		Returns:
+			An unordered input range of `PackageInfo` values is returned,
+			corresponding to all or part of the packages of the given names.
 	*/
 	auto getPackageInfos(scope string[] pack_names, bool include_errors = false)
 	{

--- a/source/dubregistry/registry.d
+++ b/source/dubregistry/registry.d
@@ -213,6 +213,21 @@ class DubRegistry {
 		return getPackageInfo(pack, include_errors);
 	}
 
+	/** Gets information about multiple packages at once.
+
+		The order of the returned packages is undefined and some of the package
+		names may not result in a `PackageInfo` to be returned at all, if no
+		package with the given name exists, so that the returned range needs
+		to be manually matched against the list of names.
+
+		This function requires only a single query to the database.
+	*/
+	auto getPackageInfos(scope string[] pack_names, bool include_errors = false)
+	{
+		return m_db.getPackages(pack_names)
+			.map!(pack => getPackageInfo(pack, include_errors));
+	}
+
 	PackageInfo getPackageInfo(DbPackage pack, bool include_errors)
 	{
 		auto rep = getRepository(pack.repository);

--- a/source/dubregistry/web.d
+++ b/source/dubregistry/web.d
@@ -118,7 +118,7 @@ class DubRegistryWebFrontend {
 		}
 
 		// limit package list to current page
-		size_t package_count = packages.length;
+		size_t pcnt = packages.length;
 		packages = packages[min(skip, $) .. min(skip + limit, $)];
 
 		// collect package infos
@@ -127,7 +127,7 @@ class DubRegistryWebFrontend {
 			infos[p.info["name"].opt!string] = p.info;
 
 		Info info;
-		info.packageCount = package_count;
+		info.packageCount = pcnt;
 		info.packages = packages
 			.map!(p => Info.Package(p.stats, infos.get(p.name, Json.init)))
 			.array;

--- a/source/dubregistry/web.d
+++ b/source/dubregistry/web.d
@@ -40,11 +40,25 @@ DubRegistryWebFrontend registerDubRegistryWebFrontend(URLRouter router, DubRegis
 
 class DubRegistryWebFrontend {
 	protected {
+		static struct CachedPackageSlot {
+			static struct Version {
+				string version_;
+				SysTime date;
+			}
+
+			BsonObjectID id;
+			string name;
+			DbPackageStats stats;
+			string[] categories;
+			Version[] versions;
+			@property SysTime dateAdded() { return id.timeStamp; }
+		}
+
 		DubRegistry m_registry;
 		UserManController m_userman;
 		Category[] m_categories;
 		Category[string] m_categoryMap;
-		DbPackage[] m_packages;
+		CachedPackageSlot[] m_packages;
 	}
 
 	this(DubRegistry registry, UserManController userman)
@@ -53,6 +67,7 @@ class DubRegistryWebFrontend {
 		m_userman = userman;
 		updateCategories();
 		updatePackageList();
+		setTimer(30.seconds, &updatePackageList, true);
 	}
 
 	@path("/")
@@ -75,7 +90,7 @@ class DubRegistryWebFrontend {
 		static import std.algorithm.sorting;
 		import std.algorithm.searching : any;
 
-		DbPackage[] packages;
+		CachedPackageSlot[] packages;
 		if (category.length) {
 			packages = m_packages
 				.filter!(p => p.categories.any!(c => c.startsWith(category)))
@@ -85,12 +100,11 @@ class DubRegistryWebFrontend {
 		}
 
 		// sort by date of last version
-		SysTime getDate(in ref DbPackage p) {
+		SysTime getDate(in ref CachedPackageSlot p) {
 			if (p.versions.length == 0) return SysTime(0, UTC());
 			return p.versions[$-1].date;
 		}
-		SysTime getDateAdded(in ref DbPackage p) { return (cast(BsonObjectID*)&p._id).timeStamp; }
-		bool compare(in ref DbPackage a, in ref DbPackage b) {
+		bool compare(in ref CachedPackageSlot a, in ref CachedPackageSlot b) {
 			bool a_has_ver = a.versions.any!(v => !v.version_.startsWith("~"));
 			bool b_has_ver = b.versions.any!(v => !v.version_.startsWith("~"));
 			if (a_has_ver != b_has_ver) return a_has_ver;
@@ -100,13 +114,22 @@ class DubRegistryWebFrontend {
 			default: std.algorithm.sorting.sort!compare(packages); break;
 			case "name": std.algorithm.sorting.sort!((a, b) => a.name < b.name)(packages); break;
 			case "score": std.algorithm.sorting.sort!((a, b) => a.stats.score > b.stats.score)(packages); break;
-			case "added": std.algorithm.sorting.sort!((a, b) => getDateAdded(a) > getDateAdded(b))(packages); break;
+			case "added": std.algorithm.sorting.sort!((a, b) => a.dateAdded > b.dateAdded)(packages); break;
 		}
 
+		// limit package list to current page
+		size_t package_count = packages.length;
+		packages = packages[min(skip, $) .. min(skip + limit, $)];
+
+		// collect package infos
+		Json[string] infos;
+		foreach (p; m_registry.getPackageInfos(packages.map!(p => p.name).array))
+			infos[p.info["name"].opt!string] = p.info;
+
 		Info info;
-		info.packageCount = packages.length;
-		info.packages = packages[min(skip, $) .. min(skip + limit, $)]
-			.map!(p => Info.Package(p.stats, m_registry.getPackageInfo(p, false).info))
+		info.packageCount = package_count;
+		info.packages = packages
+			.map!(p => Info.Package(p.stats, infos.get(p.name, Json.init)))
 			.array;
 		info.skip = skip;
 		info.limit = limit;
@@ -363,8 +386,28 @@ class DubRegistryWebFrontend {
 
 	private void updatePackageList()
 	{
-		setTimer(30.seconds, &updatePackageList);
-		m_packages = m_registry.getPackageDump().array;
+		import std.algorithm.iteration : map;
+		import core.memory : GC;
+		() @trusted { GC.collect(); } ();
+
+
+		// NOTE: all string/array data is reallocated to avoid pinning the
+		//       underlying buffer that holds the MongoDB reply
+		PackedStringAllocator strings;
+		auto newpacks = appender!(CachedPackageSlot[]);
+		newpacks.reserve(m_packages.length);
+		foreach (p; m_registry.db.getPackageDump()) {
+			CachedPackageSlot cp;
+			cp.id = p._id;
+			cp.name = strings.alloc(p.name);
+			cp.stats = p.stats;
+			cp.categories = p.categories.map!(c => strings.alloc(c)).array;
+			cp.versions = p.versions
+				.map!(v => CachedPackageSlot.Version(strings.alloc(v.version_), v.date))
+				.array;
+			newpacks ~= cp;
+		}
+		m_packages = newpacks.data;
 	}
 }
 


### PR DESCRIPTION
This removes a source of high memory use (~80MB) and also a source for what appears as a memory leak. It's not clear what keeps the memory pinned for the old approach, but it showed a steady increase in memory consumption for each package list update.
