### PR TITLE
 Improve the netlify preview to show packages

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -30,9 +30,9 @@ void startMonitoring()
 {
 	void monitorPackages()
 	{
-		sleep(10.seconds()); // give the cache a chance to warm up first
+		sleep(1.seconds()); // give the cache a chance to warm up first
 		while(true){
-			if (s_mirror.length) s_registry.mirrorRegistry(URL(s_mirror));
+			if (s_mirror.length) s_registry.mirrorRegistry(s_mirror);
 			else s_registry.updatePackages();
 			sleep(30.minutes());
 		}


### PR DESCRIPTION
As mentioned in https://github.com/dlang/dub-registry/pull/307, downloading the Json doesn't work (or well it takes 10 minutes), so I made `--mirror` support importing a manually downloaded copy of the Json file.

This is also handy for my local development, when I want to quickly nuke the entire database and on my machine `--mirror=...` doesn't work well either (could be due to my crappy internet though).