### PR TITLE
Update vibe.d dependency to allow build after dub upgrade again

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -6,7 +6,7 @@ authors "Sönke Ludwig" "Martin Nowak" "Anton Fediushin aka ohdatboi" \
 	"see GitHub for more"
 license "GPL-3.0"
 
-dependency "vibe-d" version="~>0.8.3-alpha"
+dependency "vibe-d" version="~>0.8.4-alpha.1"
 dependency "dub" version="~>1.7.0"
 dependency "userman" version="~>0.3.2"
 subConfiguration "dub" "library-nonet"


### PR DESCRIPTION
before, compilation broke after `dub upgrade` because of
```
source/dubregistry/internal/workqueue.d(59,12): Error: no property putFront for type FixedRingBuffer!(string, 0LU, true), did you mean vibe.utils.array.FixedRingBuffer!(string, 0LU, true).FixedRingBuffer.popFront?
source/dubregistry/internal/workqueue.d(62,3): Warning: statement is not reachable
```