### PR TITLE
Replace assertion by enforcement to avoid crashing the registry.

### DIFF
--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -495,7 +495,7 @@ struct DbRepository {
 		auto path = url.path.bySegment;
 		if (path.empty)
 			throw new Exception("Invalid Repository URL (no path)");
-		assert(path.front.name.empty, "got non-empty first segment in URL (before root)");
+		enforce(path.front.name.empty, "Invalid repository path (must be absolute)");
 		path.popFront;
 		if (path.empty || path.front.name.empty)
 			throw new Exception("Invalid Repository URL (missing owner)");

--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -492,11 +492,9 @@ struct DbRepository {
 		} else {
 			throw new Exception("Please input a valid project URL to a GitHub, GitLab or BitBucket project.");
 		}
-		auto path = url.path.bySegment;
+		auto path = url.path.relativeTo(InetPath("/")).bySegment;
 		if (path.empty)
 			throw new Exception("Invalid Repository URL (no path)");
-		enforce(path.front.name.empty, "Invalid repository path (must be absolute)");
-		path.popFront;
 		if (path.empty || path.front.name.empty)
 			throw new Exception("Invalid Repository URL (missing owner)");
 		owner = path.front.name;


### PR DESCRIPTION
Caused by a representation change of absolute paths between vibe-d:core and vibe-core.

Fixes dlang/dub#1441