### PR TITLE
Fix #312 - allow to manually configure the documentation url

### DIFF
--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -223,6 +223,11 @@ class DbController {
 		m_packages.update(["name": packname], update);
 	}
 
+	void setDocumentationURL(string packname, string documentationURL)
+	{
+		m_packages.update(["name": packname], ["$set": ["documentationURL": documentationURL]]);
+	}
+
 	bdata_t getPackageLogo(string packname, out bdata_t rev)
 	{
 		auto bpack = m_packages.findOne(["name": packname], ["logo": 1]);
@@ -472,6 +477,7 @@ struct DbPackage {
 	string[] categories;
 	long updateCounter = 0; // used to implement lockless read-modify-write cycles
 	@optional BsonObjectID logo; // reference to m_files
+	@optional string documentationURL;
 }
 
 struct DbRepository {

--- a/source/dubregistry/registry.d
+++ b/source/dubregistry/registry.d
@@ -253,6 +253,7 @@ class DubRegistry {
 		nfo["versions"] = Json(ret.versions.map!(v => v.info).array);
 		nfo["repository"] = serializeToJson(pack.repository);
 		nfo["categories"] = serializeToJson(pack.categories);
+		nfo["documentationURL"] = pack.documentationURL;
 		if(include_errors) nfo["errors"] = serializeToJson(pack.errors);
 
 		ret.info = nfo;
@@ -330,6 +331,11 @@ class DubRegistry {
 	void unsetPackageLogo(string pack_name)
 	{
 		m_db.setPackageLogo(pack_name, null);
+	}
+
+	void setDocumentationURL(string pack_name, string documentationURL)
+	{
+		m_db.setDocumentationURL(pack_name, documentationURL);
 	}
 
 	bdata_t getPackageLogo(string pack_name, out bdata_t rev)

--- a/source/dubregistry/web.d
+++ b/source/dubregistry/web.d
@@ -743,7 +743,7 @@ class DubRegistryFullWebFrontend : DubRegistryWebFrontend {
 	}
 
 	@auth @path("/my_packages/:packname/set_documentation_url") @errorDisplay!getMyPackagesPackage
-	void postSetLogo(scope HTTPServerRequest request, string documentation_url, string _packname, User _user)
+	void postSetDocumentationURL(scope HTTPServerRequest request, string documentation_url, string _packname, User _user)
 	{
 		enforceUserPackage(_user, _packname);
 		auto isValidURL = documentation_url.empty || documentation_url.startsWith("http://", "https://");

--- a/source/dubregistry/web.d
+++ b/source/dubregistry/web.d
@@ -308,7 +308,17 @@ class DubRegistryWebFrontend {
 			//auto sampleURLs = ["test1", "test2"]; /* TODO: actually make this array exist and embed samples generated from repository */
 			string[] sampleURLs;
 			auto activeTab = req.query.get("tab", "info");
-			render!("view_package.dt", packageName, user, packinfo, versionInfo, readmeContents, sampleURLs, urlFilter, registry, activeTab);
+			render!("view_package.dt",
+					packageName,
+					user,
+					packinfo,
+					versionInfo,
+					readmeContents,
+					sampleURLs,
+					urlFilter,
+					registry,
+					activeTab,
+			);
 		}
 	}
 
@@ -729,6 +739,16 @@ class DubRegistryFullWebFrontend : DubRegistryWebFrontend {
 		enforceUserPackage(_user, _packname);
 		m_registry.unsetPackageLogo(_packname);
 
+		redirect("/my_packages/"~_packname);
+	}
+
+	@auth @path("/my_packages/:packname/set_documentation_url") @errorDisplay!getMyPackagesPackage
+	void postSetLogo(scope HTTPServerRequest request, string documentation_url, string _packname, User _user)
+	{
+		enforceUserPackage(_user, _packname);
+		auto isValidURL = documentation_url.empty || documentation_url.startsWith("http://", "https://");
+		enforceBadRequest(isValidURL, "URL is neither null nor starts with http:// or https://");
+		m_registry.setDocumentationURL(_packname, documentation_url);
 		redirect("/my_packages/"~_packname);
 	}
 

--- a/views/my_packages.package.dt
+++ b/views/my_packages.package.dt
@@ -41,6 +41,11 @@ block body
 		form(method="POST", enctype="multipart/form-data", action="#{req.rootDir}my_packages/#{packageName}/delete_logo")
 			button.danger(type="submit") Delete
 
+		form(method="POST", action="#{req.rootDir}my_packages/#{packageName}/set_documentation_url")
+			h3 Documentation URL
+			input(name="documentation_url", value="#{pack[`documentationURL`].get!string}", pattern="https?://.+")
+			button.danger(type="submit") Change documentation URL
+
 	h2 Downloads
 	p
 		- auto stats = registry.getPackageStats(packageName).downloads;

--- a/views/view_package.dt
+++ b/views/view_package.dt
@@ -99,7 +99,9 @@ block body
 				a.tab(class=activeTab == "info" ? "active" : "", href="#{req.rootDir}packages/#{normalizedPackageName}?tab=info") Info
 			- foreach (i, sample; sampleURLs)
 				a.tab(class=activeTab == "sample_"~i.to!string ? "active" : "", href="#{req.rootDir}packages/#{normalizedPackageName}?tab=sample_#{i}")= sample
-			a.tab.external(href="http://#{normalizedPackageName}.dpldocs.info/") Documentation
+			- auto doc_url = packinfo.info["documentationURL"].get!string;
+			- doc_url = !doc_url.empty ? doc_url : "https://"~normalizedPackageName~".dpldocs.info";
+			a.tab.external(href="#{doc_url}", target="_blank") Documentation
 		- bool renderedTabContent;
 		- if (activeTab == "info")
 			- if (readmeContents.length)


### PR DESCRIPTION
Allows the user to set the documentation url. By default (aka empty string) it will point to dpldocs.info.
The URL is only verified on a very naive level, but if the user wants to put stupid things in there, it will probably be hard to prevent him from doing so anyhow.

![image](https://user-images.githubusercontent.com/4370550/39668831-e91f8878-50d9-11e8-9227-3e5a118cafe6.png)

![image](https://user-images.githubusercontent.com/4370550/39668834-f077e52a-50d9-11e8-9149-0f2f6e6d48a9.png)

with the html pattern verification disabled:

![image](https://user-images.githubusercontent.com/4370550/39668835-0194a424-50da-11e8-8151-a33641e09358.png)

CC @WebFreak001 