### PR TITLE
[trivial] Fix a few deprecations

### DIFF
--- a/source/dubregistry/registry.d
+++ b/source/dubregistry/registry.d
@@ -17,7 +17,7 @@ import std.algorithm : canFind, countUntil, filter, map, sort, swap, equal, star
 import std.array;
 import std.conv;
 import std.datetime : Clock, UTC, hours, SysTime;
-import std.digest.digest : toHexString;
+import std.digest : toHexString;
 import std.encoding : sanitize;
 import std.exception : enforce;
 import std.range : chain, walkLength;

--- a/source/dubregistry/web.d
+++ b/source/dubregistry/web.d
@@ -611,6 +611,7 @@ class DubRegistryFullWebFrontend : DubRegistryWebFrontend {
 	@auth @path("/register_package") @errorDisplay!getRegisterPackage
 	void postRegisterPackage(string url, User _user, bool ignore_fork = false)
 	{
+		import std.algorithm.searching : canFind;
 		DbRepository rep;
 		if (!url.canFind("://"))
 			url = "https://" ~ url;


### PR DESCRIPTION
The last ones come from Vibe.d:

```
../../.dub/packages/vibe-d-0.8.4-alpha.1/vibe-d/data/vibe/data/json.d(2514,25): Deprecation: function `std.exception.enforceEx!(JSONException).enforceEx!bool.enforceEx` is deprecated - Use enforce. enforceEx will be removed with 2.089.
../../.dub/packages/vibe-d-0.8.4-alpha.1/vibe-d/data/vibe/data/json.d(2514,25): Deprecation: function `std.exception.enforceEx!(JSONException).enforceEx!bool.enforceEx` is deprecated - Use enforce. enforceEx will be removed with 2.089.
../../.dub/packages/vibe-d-0.8.4-alpha.1/vibe-d/data/vibe/data/json.d(2514,25): Deprecation: function `std.exception.enforceEx!(JSONException).enforceEx!bool.enforceEx` is deprecated - Use enforce. enforceEx will be removed with 2.089.
../../.dub/packages/vibe-d-0.8.4-alpha.1/vibe-d/data/vibe/data/json.d(2514,25): Deprecation: function `std.exception.enforceEx!(JSONException).enforceEx!bool.enforceEx` is deprecated - Use enforce. enforceEx will be removed with 2.089.
```

This has already been merged into Vibe.d master, but not been tagged yet: https://github.com/vibe-d/vibe.d/pull/2130

I wasn't sure whether it's okay to tag a new alpha (IIRC last time you mentioned a special tagging script, but I couldn't find it anywhere).