### PR TITLE
Change GitLab API to version 4

### DIFF
--- a/source/dubregistry/repositories/gitlab.d
+++ b/source/dubregistry/repositories/gitlab.d
@@ -97,8 +97,8 @@ class GitLabRepository : Repository {
 		import std.uri : encodeComponent;
 		assert(path.absolute, "Passed relative path to listFiles.");
 		auto penc = () @trusted { return encodeComponent(path.toString()[1..$]); } ();
-		auto url = getAPIURLPrefix()~"/repository/tree?path="~penc~"&ref="~commit_sha;
-		auto ls = readJson(url)["values"].get!(Json[]);
+		auto url = getAPIURLPrefix()~"repository/tree?path="~penc~"&ref="~commit_sha;
+		auto ls = readJson(url).get!(Json[]);
 		RepositoryFile[] ret;
 		ret.reserve(ls.length);
 		foreach (entry; ls) {

--- a/source/dubregistry/repositories/gitlab.d
+++ b/source/dubregistry/repositories/gitlab.d
@@ -151,6 +151,6 @@ class GitLabRepository : Repository {
 
 	private string getAPIURLPrefix()
 	{
-		return m_baseURL.toString() ~ "api/v3/projects/" ~ (m_owner ~ "/" ~ m_project).urlEncode ~ "/";
+		return m_baseURL.toString() ~ "api/v4/projects/" ~ (m_owner ~ "/" ~ m_project).urlEncode ~ "/";
 	}
 }


### PR DESCRIPTION
(This pull request is work in progress and is not tested yet, I do not have the means of testing if this works currently. But will test soon.)

I expect there to be breaking API changes between version 3 and 4. But I'll test when i get home.

GitLab 11.0 deprecated use of API v3 fully, therefore GitLab support is currently broken. See https://github.com/dlang/dub-registry/issues/342