### PR TITLE
Gitlab improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ You can do so by creating a `settings.json` in the root folder of the dub-regist
 {
 	"github-user": "<your-fancy-user-name>",
 	"github-password": "<your-fancy-password>",
-	"gitlab-user": "<your-fancy-user-name>",
-	"gitlab-password": "<your-fancy-password>"
+	"gitlab-url": "https://gitlab.com/",
+	"gitlab-auth": "<gitlab-api-token from https://gitlab.com/profile/personal_access_tokens>"
 }
 ```
 

--- a/source/dubregistry/internal/utils.d
+++ b/source/dubregistry/internal/utils.d
@@ -29,10 +29,11 @@ URL black(URL url)
 			if (part.startsWith("secret", "private")) {
 				if (!replace)
 					replace = url.queryString.dup;
-				auto eq = replace.indexOf('=', i) + 1;
-				if (eq < i + part.length) { // only replace value if possible (key=value)
-					replace = replace[0 .. eq] ~ "***" ~ replace[i + part.length .. $];
-					i = eq + 3;
+				auto eq = replace.indexOf('=', i);
+				if (eq != -1 && eq + 1 < i + part.length) { // only replace value if possible (key=value)
+					// +1 to pass the '=' character
+					replace = replace[0 .. (eq + 1)] ~ "***" ~ replace[i + part.length .. $];
+					i = eq + 4;
 				} else { // otherwise replace the whole pair
 					replace = replace[0 .. i] ~ "***" ~ replace[i + part.length .. $];
 					i += 3;
@@ -51,6 +52,16 @@ URL black(URL url)
 string black(string url)
 @safe {
 	return black(URL(url)).toString();
+}
+
+@safe unittest
+{
+	assert(black("https://root:root@google.com/") == "https://***:***@google.com/");
+	assert(black("https://root:root@google.com/?secret=12345") == "https://***:***@google.com/?secret=***");
+	assert(black("https://root:root@google.com/?secret_12345") == "https://***:***@google.com/?***");
+	assert(black("https://root:root@google.com/?secret_12345&private=2") == "https://***:***@google.com/?***&private=***");
+	assert(black("https://root:root@google.com/?secret_12345&private=2&") == "https://***:***@google.com/?***&private=***&");
+	assert(black("https://root:root@google.com/?secret_12345&private=2&a=b") == "https://***:***@google.com/?***&private=***&a=b");
 }
 
 /**

--- a/source/dubregistry/repositories/gitlab.d
+++ b/source/dubregistry/repositories/gitlab.d
@@ -56,8 +56,9 @@ class GitLabRepository : Repository {
 		foreach_reverse (tag; tags) {
 			try {
 				auto tagname = tag["name"].get!string;
-				Json commit = readJson(getAPIURLPrefix()~"repository/commits/"~tag["commit"]["id"].get!string~"?private_token="~m_authToken, true, true);
-				ret ~= RefInfo(tagname, tag["commit"]["id"].get!string, SysTime.fromISOExtString(commit["committed_date"].get!string));
+				auto commit = tag["commit"]["id"].get!string;
+				auto date = SysTime.fromISOExtString(tag["commit"]["committed_date"].get!string);
+				ret ~= RefInfo(tagname, commit, date);
 				logDebug("Found tag for %s/%s: %s", m_owner, m_project, tagname);
 			} catch( Exception e ){
 				throw new Exception("Failed to process tag "~tag["name"].get!string~": "~e.msg);
@@ -74,8 +75,9 @@ class GitLabRepository : Repository {
 		RefInfo[] ret;
 		foreach_reverse( branch; branches ){
 			auto branchname = branch["name"].get!string;
-			Json commit = readJson(getAPIURLPrefix()~"repository/commits/"~branch["commit"]["id"].get!string~"?private_token="~m_authToken, true, true);
-			ret ~= RefInfo(branchname, branch["commit"]["id"].get!string, SysTime.fromISOExtString(commit["committed_date"].get!string));
+			auto commit = branch["commit"]["id"].get!string;
+			auto date = SysTime.fromISOExtString(branch["commit"]["committed_date"].get!string);
+			ret ~= RefInfo(branchname, commit, date);
 			logDebug("Found branch for %s/%s: %s", m_owner, m_project, branchname);
 		}
 		return ret;


### PR DESCRIPTION
from #342 I saw that there were several useless HTTP requests and now the black function also censors query parameters starting with private or secret (fixing that the gitlab access token is dumped to the user)