### PR TITLE
Use a debug Heroku buildpack for now

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
   "keywords": ["d", "dlang", "dub", "registry"],
   "buildpacks": [
     {
-      "url": "http://github.com/MartinNowak/heroku-buildpack-d.git"
+      "url": "http://github.com/wilzbach/heroku-buildpack-d.git"
     }
   ],
   "addons": [


### PR DESCRIPTION
This simply removes the release mode from Martin's buildpack.
I'm not sure yet on the best way to make this configurable for the users, but when I do I will make an upstream PR to Martin's buildpack.
However, for now this should drastically reduce the build times and provide us with stack traces.