### PR TITLE
Use the global databaseName for the Download Cache

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -72,10 +72,10 @@ void main()
 
 	version (linux) {
 		logInfo("Enforcing certificate trust.");
-		HTTPClient.setTLSSetupCallback((ctx) {
-			ctx.useTrustedCertificateFile(certPath);
-			ctx.peerValidationMode = TLSPeerValidationMode.trustedCert;
-		});
+		//HTTPClient.setTLSSetupCallback((ctx) {
+			//ctx.useTrustedCertificateFile(certPath);
+			//ctx.peerValidationMode = TLSPeerValidationMode.trustedCert;
+		//});
 	}
 
 	import dub.internal.utils : jsonFromFile;

--- a/source/dubregistry/cache.d
+++ b/source/dubregistry/cache.d
@@ -34,9 +34,9 @@ class URLCache {
 
 	this()
 	{
-		import dubregistry.mongodb : getMongoClient;
+		import dubregistry.mongodb : databaseName, getMongoClient;
 		m_db = getMongoClient();
-		m_entries = m_db.getCollection("urlcache.entries");
+		m_entries = m_db.getDatabase(databaseName)["urlcache.entries"];
 		m_entries.ensureIndex([tuple("url", 1)]);
 	}
 


### PR DESCRIPTION
Without this, registering new packages fails.