### PR TITLE
Add missing import for std.typecons : tuple

### DIFF
--- a/source/dubregistry/web.d
+++ b/source/dubregistry/web.d
@@ -74,6 +74,7 @@ class DubRegistryWebFrontend {
 	{
 		import std.algorithm.comparison : min;
 		import std.algorithm.iteration : filter, map;
+		import std.typecons : tuple;
 
 		static import std.algorithm.sorting;
 		import std.algorithm.searching : any;


### PR DESCRIPTION
This fixes the deprecation warning:

```
source/dubregistry/web.d(120,10): Deprecation: dubregistry.dbcontroller.tuple is not visible from module web
```