### PR TITLE
Revert "Disable certificate trust"

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -72,10 +72,10 @@ void main()
 
 	version (linux) {
 		logInfo("Enforcing certificate trust.");
-		//HTTPClient.setTLSSetupCallback((ctx) {
-			//ctx.useTrustedCertificateFile(certPath);
-			//ctx.peerValidationMode = TLSPeerValidationMode.trustedCert;
-		//});
+		HTTPClient.setTLSSetupCallback((ctx) {
+			ctx.useTrustedCertificateFile(certPath);
+			ctx.peerValidationMode = TLSPeerValidationMode.trustedCert;
+		});
 	}
 
 	import dub.internal.utils : jsonFromFile;


### PR DESCRIPTION
This reverts commit 8603173b9b7410dc2d732b485d5d024fd46214ad.

This was necessary to be able to use the GitHub querying at Heroku and locally.
We should probably figure out what's happening here.