### PR TITLE
Update input style

### DIFF
--- a/public/styles/common.css
+++ b/public/styles/common.css
@@ -339,6 +339,12 @@ button.primary:hover, button.primary:focus {
 
 .clipboard-pkg-row input {
 	width: 280px;
+	background: #fff;
+	color: #000;
+	border: 1px solid #ccc;
+	border-radius: 3px;
+	padding: 4px;
+	margin: 2px;
 }
 
 /********************/


### PR DESCRIPTION
On some os(eg. gnome shell with dark gtk theme) the default background colours for input boxes is black.
![screenshot from 2018-07-15 20-20-28](https://user-images.githubusercontent.com/4217037/42736813-adafdd86-886c-11e8-9a57-5edb9869fbe6.png)

This is a proposal for fixing this issue.