### PR TITLE
Fix #372 - libssl.so.1.0.0 not found in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/mongodb:3.7
+FROM bitnami/mongodb:3.6-debian-8
 
 # Based on https://github.com/rracariu/docker
 
@@ -6,7 +6,7 @@ MAINTAINER "DLang Community <community@dlang.io>"
 
 EXPOSE 9095
 
-RUN apt-get update && apt-get install -y netcat unzip imagemagick
+RUN apt-get update && apt-get install -y netcat unzip imagemagick libssl-dev
 
 COPY dub-registry /opt/dub-registry/dub-registry
 COPY public /opt/dub-registry/public

--- a/README.md
+++ b/README.md
@@ -84,7 +84,8 @@ Deploy your private dub-registry with Docker
 The [dlangcommunity/dub-registry](https://hub.docker.com/r/dlangcommunity/dub-registry/) Docker image is available for an easy setup:
 
 ```
-docker run --rm -ti -p 9095:9095 -v $DUB_REGISTRY_HOME:/bitnami -v $DUB_REGISTRY_HOME:/dub dlang-community/dub-registry
+export DUB_REGISTRY_HOME="$PWD"
+docker run --rm -ti -p 9095:9095 -v $DUB_REGISTRY_HOME:/bitnami -v $DUB_REGISTRY_HOME:/dub dlangcommunity/dub-registry
 ```
 
 This will run both `mongodb` and `dub-registry` while persisting the database in the `$DUB_REGISTRY_HOME` location. The registry is accessible at http://127.0.0.1:9095
@@ -92,7 +93,7 @@ This will run both `mongodb` and `dub-registry` while persisting the database in
 To run it as a daemon and make it auto-restart use:
 
 ```
-docker run -d --restart=always -ti -p 9095:9095 -v $DUB_REGISTRY_HOME:/bitnami -v $DUB_REGISTRY_HOME:/dub dlang-community/dub-registry
+docker run -d --restart=always -ti -p 9095:9095 -v $DUB_REGISTRY_HOME:/bitnami -v $DUB_REGISTRY_HOME:/dub dlangcommunity/dub-registry
 ```
 
 The registry can be configured by adding the `settings.json` file in `$DUB_REGISTRY_HOME` folder.


### PR DESCRIPTION
Looks like they changed the Docker image. Better fix it to sth. stable.
Debian 8 is used because the binary is built on Travis which still uses OpenSSL 1.0.0.