### PR TITLE
Support for GitLab projects inside subgroups

### DIFF
--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -509,9 +509,13 @@ struct DbRepository {
 		path.popFront;
 		if (path.empty || path.front.name.empty)
 			throw new Exception("Invalid Repository URL (missing project)");
-		project = path.front.name;
+
+		if(kind == "gitlab")
+			project = path.map!"a.name".join("/");
+		else
+			project = path.front.name;
 		path.popFront;
-		if (!path.empty)
+		if (!path.empty && kind != "gitlab")
 			throw new Exception("Invalid Repository URL (got more than owner and project)");
 	}
 
@@ -523,6 +527,8 @@ struct DbRepository {
 		assert(r == DbRepository("bitbucket", "bar", "baz"));
 		r.parseURL(URL("https://gitlab.com/foo/bar"));
 		assert(r == DbRepository("gitlab", "foo", "bar"));
+		r.parseURL(URL("https://gitlab.com/group/subgroup/project"));
+		assert(r == DbRepository("gitlab", "group", "subgroup/project"));
 		assertThrown(r.parseURL(URL("ftp://github.com/foo/bar")));
 		assertThrown(r.parseURL(URL("ftp://github.com/foo/bar")));
 		assertThrown(r.parseURL(URL("http://github.com/foo/")));

--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -510,7 +510,7 @@ struct DbRepository {
 		if (path.empty || path.front.name.empty)
 			throw new Exception("Invalid Repository URL (missing project)");
 
-		if(kind == "gitlab")
+		if(kind == "gitlab")  // Allow any number of segments, as GitLab's subgroups can be nested
 			project = path.map!"a.name".join("/");
 		else
 			project = path.front.name;
@@ -527,8 +527,8 @@ struct DbRepository {
 		assert(r == DbRepository("bitbucket", "bar", "baz"));
 		r.parseURL(URL("https://gitlab.com/foo/bar"));
 		assert(r == DbRepository("gitlab", "foo", "bar"));
-		r.parseURL(URL("https://gitlab.com/group/subgroup/project"));
-		assert(r == DbRepository("gitlab", "group", "subgroup/project"));
+		r.parseURL(URL("https://gitlab.com/group/subgroup/subsubgroup/project"));
+		assert(r == DbRepository("gitlab", "group", "subgroup/subsubgroup/project"));
 		assertThrown(r.parseURL(URL("ftp://github.com/foo/bar")));
 		assertThrown(r.parseURL(URL("ftp://github.com/foo/bar")));
 		assertThrown(r.parseURL(URL("http://github.com/foo/")));

--- a/views/my_packages.register.dt
+++ b/views/my_packages.register.dt
@@ -21,7 +21,7 @@ block body
 		form(method="POST", action="#{req.rootDir}register_package")
 			p
 				label(for="project") Repository URL
-				input(type="text", name="url", value=url, pattern="^(https?:\/\/)?(www\.)?(github(\.com)?|gitlab(\.com)?|bitbucket(\.org)?)(/[^/]+)+/[^/]+([?#.].*)?$", placeholder="github.com/user/repository")
+				input(type="text", name="url", value=url, pattern="^(https?:\/\/)?(www\.)?(((github(\.com)?|bitbucket(\.org)?)\/[^/]+\/[^/]+([?#.].*)?)|(gitlab(\.com)?(\/[^/]+)+\/[^/]+([?#.].*)?))$", placeholder="github.com/user/repository")
 				span.repoError Please enter a valid project URL or tuple to a GitHub, GitLab or BitBucket project, such as #[code https://gitlab.com/dlang/dub] or #[code bitbucket/dlang/dub].
 			p
 				button(type="submit") Register package

--- a/views/my_packages.register.dt
+++ b/views/my_packages.register.dt
@@ -2,7 +2,7 @@ extends layout
 
 block title
 	- auto title = "Add new package";
-	
+
 block body
 
 	- if(error.length)
@@ -15,13 +15,13 @@ block body
 	.inputForm
 		h1 Add new package
 			p.light
-				a.blind(href="#{req.rootDir}publish") Learn more 
+				a.blind(href="#{req.rootDir}publish") Learn more
 				| about publishing.
 
 		form(method="POST", action="#{req.rootDir}register_package")
 			p
 				label(for="project") Repository URL
-				input(type="text", name="url", value=url, pattern="^(https?://)?(www\.)?(github(\.com)?|gitlab(\.com)?|bitbucket(\.org)?)/[^/]+/[^/]+([?#.].*)?$", placeholder="github.com/user/repository")
+				input(type="text", name="url", value=url, pattern="^(https?:\/\/)?(www\.)?(github(\.com)?|gitlab(\.com)?|bitbucket(\.org)?)(/[^/]+)+/[^/]+([?#.].*)?$", placeholder="github.com/user/repository")
 				span.repoError Please enter a valid project URL or tuple to a GitHub, GitLab or BitBucket project, such as #[code https://gitlab.com/dlang/dub] or #[code bitbucket/dlang/dub].
 			p
 				button(type="submit") Register package


### PR DESCRIPTION
This pull requests allows to register packages for GitLab projects placed into subgroups.

Currently the problem is that URL validation throws an error, because it expects url like *service*[.com]//*owner*/*project*. However, GitLab's subgroups allow URLs like gitlab.com/*owner*/*subgroup*/*subsubgroup*/*project*.

This pull request renames **m_project** to **m_projectPath** in **GitLabRepository** and allows it to store the *subgroup*/*subsubgroup*/*project* as is with slashes - so the first part after the URL is put into **m_owner** as it was before, but the rest is joined and put into **m_projectPath** even if contains slashes.

The regex is adjusted as well so that multiple slashed parts are allowed.

This will fix #374.