### PR TITLE
Environment fallback for config variables

### DIFF
--- a/app.json
+++ b/app.json
@@ -25,6 +25,30 @@
     "GENERATE_DEFAULT_DATA": {
       "description": "Whether the database should be pre-filled. Use '0' for no.",
       "required": false
+    },
+    "GITHUB_USER": {
+      "description": "GitHub user for authenticated access",
+      "required": false
+    },
+    "GITHUB_PASSWORD": {
+      "description": "GitHub password for authenticated access",
+      "required": false
+    },
+    "GITLAB_URL": {
+      "description": "GitLab URL for authenticated access",
+      "required": false
+    },
+    "GITLAB_AUTH": {
+      "description": "GitLab authentication for authenticated access",
+      "required": false
+    },
+    "BITBUCKET_USER": {
+      "description": "BitBucket user for authenticated access",
+      "required": false
+    },
+    "BITBUCKET_PASSWORD": {
+      "description": "BitBucket password for authenticated access",
+      "required": false
     }
   }
 }

--- a/source/app.d
+++ b/source/app.d
@@ -102,6 +102,16 @@ void main()
 	bool noMonitoring;
 	setLogFile("log.txt", LogLevel.diagnostic);
 
+    version (linux)
+    {
+    	// register memory error handler on heroku
+    	if ("DYNO" in environment)
+    	{
+			import etc.linux.memoryerror : registerMemoryErrorHandler;
+        	registerMemoryErrorHandler();
+        }
+    }
+
 	string hostname = "code.dlang.org";
 
 	readOption("mirror", &s_mirror, "URL of a package registry that this instance should mirror (WARNING: will overwrite local database!)");

--- a/source/app.d
+++ b/source/app.d
@@ -59,7 +59,7 @@ shared static this()
 void defaultInit(UserManController userMan, DubRegistry registry)
 {
 	if (environment.get("GENERATE_DEFAULT_DATA", "0") == "1" &&
-		registry.getPackageDump().empty)
+		registry.getPackageDump().empty && userMan.getUserCount() == 0)
 	{
 		logInfo("'GENERATE_DEFAULT_DATA' is set and an empty database has been detected. Inserting dummy data.");
 		auto userId = userMan.registerUser("dummy@dummy.org", "dummyUser",


### PR DESCRIPTION
Allows to set the config variables optionally via environment variables (soft fallback)

This is useful for e.g. the Heroku Apps where the app is ephermal and all configuration is done via environment variables, which can be inherited automatically to new review instances.