### PR TITLE
WIP: Add pagination for search results

### DIFF
--- a/source/dubregistry/api.d
+++ b/source/dubregistry/api.d
@@ -121,6 +121,7 @@ override {
 	@method(HTTPMethod.GET)
 	SearchResult[] search(string q) {
 		return m_registry.searchPackages(q)
+			.packages
 			.map!(p => SearchResult(p.name, p.info["description"].opt!string, p.version_))
 			.array;
 	}

--- a/source/dubregistry/registry.d
+++ b/source/dubregistry/registry.d
@@ -97,10 +97,15 @@ class DubRegistry {
 		return m_updateQueue.getPosition(pack_name);
 	}
 
-	auto searchPackages(string query)
+	size_t matchingPackageCount(string query)
+	{
+		return m_db.matchingPackageCount(query);
+	}
+
+	auto searchPackages(string query, ulong skip = 0, ulong limit = 20)
 	{
 		static struct Info { string name; DbPackageStats stats; DbPackageVersion _base; alias _base this; }
-		return m_db.searchPackages(query).filter!(p => p.versions.length > 0).map!(p =>
+		return m_db.searchPackages(query, skip, limit).filter!(p => p.versions.length > 0).map!(p =>
 			Info(p.name, p.stats, m_db.getVersionInfo(p.name, p.versions[$ - 1].version_)));
 	}
 

--- a/source/dubregistry/registry.d
+++ b/source/dubregistry/registry.d
@@ -97,16 +97,16 @@ class DubRegistry {
 		return m_updateQueue.getPosition(pack_name);
 	}
 
-	size_t matchingPackageCount(string query)
-	{
-		return m_db.matchingPackageCount(query);
-	}
-
-	auto searchPackages(string query, ulong skip = 0, ulong limit = 20)
+	auto searchPackages(string query, int skip = 0, int limit = 20)
 	{
 		static struct Info { string name; DbPackageStats stats; DbPackageVersion _base; alias _base this; }
-		return m_db.searchPackages(query, skip, limit).filter!(p => p.versions.length > 0).map!(p =>
-			Info(p.name, p.stats, m_db.getVersionInfo(p.name, p.versions[$ - 1].version_)));
+		auto r = m_db.searchPackages(query, skip, limit);
+		
+		return tuple!("packages", "count")(
+			r.packages
+				.filter!(p => p.versions.length > 0)
+				.map!(p => Info(p.name, p.stats, m_db.getVersionInfo(p.name, p.versions[$ - 1].version_))),
+			r.count);
 	}
 
 	RepositoryInfo getRepositoryInfo(DbRepository repository)

--- a/source/dubregistry/web.d
+++ b/source/dubregistry/web.d
@@ -469,11 +469,27 @@ class DubRegistryFullWebFrontend : DubRegistryWebFrontend {
 		m_usermanauth = new UserManWebAuthenticator(userman);
 	}
 
-	void querySearch(string q = "")
+	void querySearch(string q = "", ulong skip = 0, ulong limit = 20)
 	{
-		auto results = m_registry.searchPackages(q);
-		auto queryString = q;
-		render!("search_results.dt", queryString, results);
+		auto res = m_registry.searchPackages(q, skip, limit);
+
+		static struct Info {
+			typeof(res) results;
+			size_t found;
+			ulong skip;
+			ulong limit;
+			string query;
+		}
+
+		Info info = {
+			results: res,
+			found: q.strip.length ? m_registry.matchingPackageCount(q) : m_packages.length,
+			skip: skip,
+			limit: limit,
+			query: q,
+		};
+
+		render!("search_results.dt", info);
 	}
 
 	void getGettingStarted() { render!("getting_started.dt"); }

--- a/source/dubregistry/web.d
+++ b/source/dubregistry/web.d
@@ -469,12 +469,12 @@ class DubRegistryFullWebFrontend : DubRegistryWebFrontend {
 		m_usermanauth = new UserManWebAuthenticator(userman);
 	}
 
-	void querySearch(string q = "", ulong skip = 0, ulong limit = 20)
+	void querySearch(string q = "", int skip = 0, int limit = 20)
 	{
 		auto res = m_registry.searchPackages(q, skip, limit);
 
 		static struct Info {
-			typeof(res) results;
+			typeof(res.packages) results;
 			size_t found;
 			ulong skip;
 			ulong limit;
@@ -482,8 +482,8 @@ class DubRegistryFullWebFrontend : DubRegistryWebFrontend {
 		}
 
 		Info info = {
-			results: res,
-			found: q.strip.length ? m_registry.matchingPackageCount(q) : m_packages.length,
+			results: res.packages,
+			found: q.strip.length ? res.count : m_packages.length,
 			skip: skip,
 			limit: limit,
 			query: q,

--- a/views/search_results.dt
+++ b/views/search_results.dt
@@ -2,10 +2,12 @@ extends layout
 
 block title
 	- import dubregistry.viewutils;
-	- auto title = "Search results for \"" ~ queryString ~ "\"";
+	- import std.algorithm.comparison : min;
+
+	- auto title = "Search results for \"" ~ info.query ~ "\"";
 
 block body
-	p Search results for: <em>#{queryString}</em>
+	p Search results for: <em>#{info.query}</em>
 
 	- size_t count = 0;
 
@@ -16,7 +18,7 @@ block body
 			th Date
 			th Score
 			th Description
-		- foreach (p; results)
+		- foreach (p; info.results)
 			- auto desc = p.info["description"].opt!string;
 			- auto ver = p.version_;
 			- count++;
@@ -35,4 +37,18 @@ block body
 				- else
 					td #{desc[0 .. 98]}&hellip;
 
-	p Found #{count} packages.
+	ul.pageNav
+		- foreach (i; 0 .. (info.found + info.limit - 1) / info.limit)
+			- if (i * info.limit == info.skip)
+				li.selected= i+1
+			- else
+				li: a(href="?q=#{info.query}&skip=#{i*info.limit}&limit=#{info.limit}")= i+1
+	ul.pageNav.perPage
+		- static immutable limit_enum = [10, 20, 50, 100];
+		- foreach (limit; limit_enum)
+			- if (info.limit == limit)
+				li.selected= limit
+			- else
+				li: a(href="?q=#{info.query}&?skip=#{info.skip}&limit=#{limit}")= limit
+
+	p Displaying results #{info.skip+1} to #{min(info.skip+info.limit+1, info.found)} of #{info.found} packages found.


### PR DESCRIPTION
Somewhat fixes #296, fixes #341, fixes #346, fixes #322.

Problem is in the vibe-d's mongo driver, which throws:
```
500 - Internal Server Error

Internal Server Error

Internal error information:
vibe.db.mongo.connection.MongoDriverException@../../../.dub/packages/vibe-d-0.8.4/vibe-d/mongodb/vibe/db/mongo/cursor.d(304): Query failed. Does the database exist?
----------------
/usr/include/dlang/dmd/std/exception.d:515 @safe void std.exception.bailOut!(vibe.db.mongo.connection.MongoDriverException).bailOut(immutable(char)[], ulong, scope const(char)[]) [0x3032d7fe]
/usr/include/dlang/dmd/std/exception.d:436 @safe bool std.exception.enforce!(vibe.db.mongo.connection.MongoDriverException).enforce!(bool).enforce(bool, lazy const(char)[], immutable(char)[], ulong) [0x3032d77a]
../../../.dub/packages/vibe-d-0.8.4/vibe-d/mongodb/vibe/db/mongo/cursor.d:304 @safe void vibe.db.mongo.cursor.MongoCursorData!(vibe.data.bson.Bson).MongoCursorData.handleReply(long, vibe.db.mongo.flags.ReplyFlags, int, int) [0x303ee6b0]
../../../.dub/packages/vibe-d-0.8.4/vibe-d/mongodb/vibe/db/mongo/connection.d:393 @safe int vibe.db.mongo.connection.MongoConnection.recvReply!(vibe.data.bson.Bson).recvReply(int, scope void delegate(long, vibe.db.mongo.flags.ReplyFlags, int, int) @safe, scope void delegate(ulong, ref vibe.data.bson.Bson) @safe) [0x303ef14c]
../../../.dub/packages/vibe-d-0.8.4/vibe-d/mongodb/vibe/db/mongo/connection.d:253 @safe void vibe.db.mongo.connection.MongoConnection.query!(vibe.data.bson.Bson).query(immutable(char)[], vibe.db.mongo.flags.QueryFlags, int, int, vibe.data.bson.Bson, vibe.data.bson.Bson, scope void delegate(long, vibe.db.mongo.flags.ReplyFlags, int, int) @safe, scope void delegate(ulong, ref vibe.data.bson.Bson) @safe) [0x303ef7b3]
../../../.dub/packages/vibe-d-0.8.4/vibe-d/mongodb/vibe/db/mongo/cursor.d:367 @safe void vibe.db.mongo.cursor.MongoFindCursor!(immutable(char)[][immutable(char)[]][immutable(char)[]], vibe.data.bson.Bson, vibe.data.bson.Bson[immutable(char)[]]).MongoFindCursor.startIterating() [0x304096f5]
../../../.dub/packages/vibe-d-0.8.4/vibe-d/mongodb/vibe/db/mongo/cursor.d:233 @property @safe bool vibe.db.mongo.cursor.MongoCursorData!(vibe.data.bson.Bson).MongoCursorData.empty() [0x303ee516]
../../../.dub/packages/vibe-d-0.8.4/vibe-d/mongodb/vibe/db/mongo/cursor.d:60 @property @safe bool vibe.db.mongo.cursor.MongoCursor!(vibe.data.bson.Bson).MongoCursor.empty() [0x303ee24f]
/usr/include/dlang/dmd/std/algorithm/iteration.d:591 @property @safe bool std.algorithm.iteration.MapResult!(vibe.data.bson.deserializeBson!(dubregistry.dbcontroller.DbPackage).deserializeBson, vibe.db.mongo.cursor.MongoCursor!(vibe.data.bson.Bson).MongoCursor).MapResult.empty() [0x3033fe88]
/usr/include/dlang/dmd/std/array.d:134 @safe dubregistry.dbcontroller.DbPackage[] std.array.array!(std.algorithm.iteration.MapResult!(vibe.data.bson.deserializeBson!(dubregistry.dbcontroller.DbPackage).deserializeBson, vibe.db.mongo.cursor.MongoCursor!(vibe.data.bson.Bson).MongoCursor).MapResult).array(std.algorithm.iteration.MapResult!(vibe.data.bson.deserializeBson!(dubregistry.dbcontroller.DbPackage).deserializeBson, vibe.db.mongo.cursor.MongoCursor!(vibe.data.bson.Bson).MongoCursor).MapResult) [0x30340080]
source/dubregistry/dbcontroller.d:334 @safe dubregistry.dbcontroller.DbPackage[] dubregistry.dbcontroller.DbController.searchPackages(immutable(char)[], ulong, ulong) [0x3039814f]
source/dubregistry/registry.d:108 @safe std.algorithm.iteration.MapResult!(dubregistry.registry.DubRegistry.searchPackages(immutable(char)[], ulong, ulong).__lambda6, std.algorithm.iteration.FilterResult!(dubregistry.registry.DubRegistry.searchPackages(immutable(char)[], ulong, ulong).__lambda5, dubregistry.dbcontroller.DbPackage[]).FilterResult).MapResult dubregistry.registry.DubRegistry.searchPackages(immutable(char)[], ulong, ulong) [0x304bdf73]
source/dubregistry/web.d:474 void dubregistry.web.DubRegistryFullWebFrontend.querySearch(immutable(char)[], ulong, ulong) [0x3049bce9]
../../../.dub/packages/vibe-d-0.8.4/vibe-d/web/vibe/web/web.d:1024 void vibe.web.web.handleRequest!("querySearch", dubregistry.web.DubRegistryFullWebFrontend.querySearch(immutable(char)[], ulong, ulong), dubregistry.web.DubRegistryFullWebFrontend).handleRequest(vibe.http.server.HTTPServerRequest, vibe.http.server.HTTPServerResponse, dubregistry.web.DubRegistryFullWebFrontend, vibe.web.web.WebInterfaceSettings) [0x3045b2d3]
../../../.dub/packages/vibe-d-0.8.4/vibe-d/web/vibe/web/web.d:194 @trusted void vibe.web.web.registerWebInterface!(dubregistry.web.DubRegistryFullWebFrontend, 5).registerWebInterface(vibe.http.router.URLRouter, dubregistry.web.DubRegistryFullWebFrontend, vibe.web.web.WebInterfaceSettings).__lambda4(vibe.http.server.HTTPServerRequest, vibe.http.server.HTTPServerResponse) [0x30458b30]
../../../.dub/packages/vibe-d-0.8.4/vibe-d/http/vibe/http/router.d:218 @safe bool vibe.http.router.URLRouter.handleRequest(vibe.http.server.HTTPServerRequest, vibe.http.server.HTTPServerResponse).__lambda4!(ulong, immutable(char)[][]).__lambda4(ulong, scope immutable(char)[][]) [0x3074cfe3]
../../../.dub/packages/vibe-d-0.8.4/vibe-d/http/vibe/http/router.d:674 const @safe bool vibe.http.router.MatchTree!(vibe.http.router.Route).MatchTree.doMatch(immutable(char)[], scope bool delegate(ulong, scope immutable(char)[][]) @safe) [0x3074f791]
../../../.dub/packages/vibe-d-0.8.4/vibe-d/http/vibe/http/router.d:607 @safe bool vibe.http.router.MatchTree!(vibe.http.router.Route).MatchTree.match(immutable(char)[], scope bool delegate(ulong, scope immutable(char)[][]) @safe) [0x3074f093]
../../../.dub/packages/vibe-d-0.8.4/vibe-d/http/vibe/http/router.d:211 @safe void vibe.http.router.URLRouter.handleRequest(vibe.http.server.HTTPServerRequest, vibe.http.server.HTTPServerResponse) [0x3074cca4]
../../../.dub/packages/vibe-d-0.8.4/vibe-d/http/vibe/http/server.d:2247 @safe bool vibe.http.server.handleRequest(vibe.internal.interfaceproxy.InterfaceProxy!(vibe.core.stream.Stream).InterfaceProxy, vibe.core.net.TCPConnection, vibe.http.server.HTTPServerContext, ref vibe.http.server.HTTPServerSettings, ref bool, scope stdx.allocator.IAllocator) [0x307aaad7]
../../../.dub/packages/vibe-d-0.8.4/vibe-d/http/vibe/http/server.d:241 @trusted void vibe.http.server.handleHTTPConnection(vibe.core.net.TCPConnection, vibe.http.server.HTTPServerContext).__lambda4() [0x307a8f80]
../../../.dub/packages/vibe-d-0.8.4/vibe-d/http/vibe/http/server.d:233 @safe void vibe.http.server.handleHTTPConnection(vibe.core.net.TCPConnection, vibe.http.server.HTTPServerContext) [0x307a8c8f]
../../../.dub/packages/vibe-d-0.8.4/vibe-d/http/vibe/http/server.d:2006 nothrow @safe void vibe.http.server.listenHTTPPlain(vibe.http.server.HTTPServerSettings, void delegate(vibe.http.server.HTTPServerRequest, vibe.http.server.HTTPServerResponse) @safe).doListen(vibe.http.server.HTTPServerContext, bool, bool).__lambda4(vibe.core.net.TCPConnection) [0x307594b1]
../../../.dub/packages/vibe-core-1.4.1/vibe-core/source/vibe/core/task.d:556 void vibe.core.task.TaskFuncInfo.set!(void delegate(vibe.core.net.TCPConnection) @safe, vibe.core.net.TCPConnection).set(ref void delegate(vibe.core.net.TCPConnection) @safe, ref vibe.core.net.TCPConnection).callDelegate(ref vibe.core.task.TaskFuncInfo) [0x30849c38]
../../../.dub/packages/vibe-core-1.4.1/vibe-core/source/vibe/core/task.d:577 void vibe.core.task.TaskFuncInfo.call() [0x3082ad11]
../../../.dub/packages/vibe-core-1.4.1/vibe-core/source/vibe/core/task.d:388 nothrow void vibe.core.task.TaskFiber.run() [0x3082a319]
??:? void core.thread.Fiber.run() [0x308ee363]
??:? fiber_entryPoint [0x308ee232]
??:? [0xffffffff]
```
And logs the following:
```
MongoDB reply was longer than expected, skipping the rest: 220 vs. 36
```

When there are too many search results for the specified query (for example, `d`, `https`, ...).

With pagination user can search for `d` and get some results, but page still crashes when user continues browsing the results. For example, for `d` first 13 pages are displayed OK but it crashes when user switches to the page no. 14.