### PR TITLE
Replace readme github password with access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ You can do so by creating a `settings.json` in the root folder of the dub-regist
 
 ```json
 {
-	"github-user": "<your-fancy-user-name>",
-	"github-password": "<your-fancy-password>",
+	"github-user": "<github-user-name>",
+	"github-password": "<github-personal-access-token from https://github.com/settings/tokens>",
 	"gitlab-url": "https://gitlab.com/",
 	"gitlab-auth": "<gitlab-api-token from https://gitlab.com/profile/personal_access_tokens>",
 	"bitbucket-user": "<your-fancy-user-name>",
@@ -42,7 +42,9 @@ You can do so by creating a `settings.json` in the root folder of the dub-regist
 }
 ```
 
-It's recommended to create a separate account for the DUB registry GitHub authentication. Equally, if no GitLab packages are used in your local repository, no GitLab authentication is needed.
+It's absolutely recommended to create a personal access token without any extra permissions for your GitHub account instead of entering your password plain text into the settings file. You can generate an access token at https://github.com/settings/tokens (Settings -> Developer Settings -> Personal access tokens)
+
+Note that previous versions of this README stated to create a separate account and write down the password in plain text. This should be considered insecure as special characters in your password such as '@' could expose following parts of the password to the user.
 
 ### SECURITY NOTICE
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ You can do so by creating a `settings.json` in the root folder of the dub-regist
 }
 ```
 
+It's recommended to create a separate account for the DUB registry GitHub authentication. Equally, if no GitLab packages are used in your local repository, no GitLab authentication is needed.
+
 It's absolutely recommended to create a personal access token without any extra permissions for your GitHub account instead of entering your password plain text into the settings file. You can generate an access token at https://github.com/settings/tokens (Settings -> Developer Settings -> Personal access tokens)
 
-Note that previous versions of this README stated to create a separate account and write down the password in plain text. This should be considered insecure as special characters in your password such as '@' could expose following parts of the password to the user.
+Note that previous versions of this README stated to write down the password in plain text. This should be considered insecure as special characters in your password such as '@' could expose following parts of the password to the users.
 
 ### SECURITY NOTICE
 


### PR DESCRIPTION
putting plain text account passwords into webserver text files is stupid

Personal access tokens on github are a low-privilege replacement for the user password for HTTP basic authentication (which is being used)