### PR TITLE
Expose /infos endpoint

### DIFF
--- a/source/dubregistry/api.d
+++ b/source/dubregistry/api.d
@@ -95,6 +95,7 @@ interface IPackages {
 	@path(":name/:version/info")
 	Json getInfo(string _name, string _version, bool minimize = false);
 
+	@path(":name/:version/infos")
 	Json[string] getInfos(string[] packages, bool include_dependencies = false, bool minimize = false);
 }
 


### PR DESCRIPTION
This was forgotten in the respective PR (https://github.com/dlang/dub-registry/pull/278).

See also: https://github.com/dlang/dub-registry/pull/278/files#diff-208dd7dc9f2b52b6520f8975b543f926R98