### PR TITLE
fix space in package registration

### DIFF
--- a/views/my_packages.register.dt
+++ b/views/my_packages.register.dt
@@ -16,7 +16,7 @@ block body
 		h1 Add new package
 			p.light
 				a.blind(href="#{req.rootDir}publish") Learn more
-				| about publishing.
+				|  about publishing.
 
 		form(method="POST", action="#{req.rootDir}register_package")
 			p


### PR DESCRIPTION
before:
![registration page without space](https://wfr.moe/f6ZvJ4.png)

after:
![registration page with space](https://wfr.moe/f6ZgMs.png)