### PR TITLE
Fix issue #436 - Update GitLab APIs

### DIFF
--- a/source/dubregistry/repositories/gitlab.d
+++ b/source/dubregistry/repositories/gitlab.d
@@ -148,7 +148,8 @@ class GitLabRepository : Repository {
 		if (ver.startsWith("~")) ver = ver[1 .. $];
 		else ver = ver;
 		auto venc = () @trusted { return encodeComponent(ver); } ();
-		return m_baseURL.toString()~m_owner~"/"~m_projectPath~"/repository/archive.zip?ref="~venc;
+		// The "sha" parameter in GitLab's API v4 accepts the tag, branch or the  the commit sha (see https://docs.gitlab.com/ee/api/repositories.html#get-file-archive)
+		return getAPIURLPrefix() ~ "repository/archive.zip?sha="~venc;
 	}
 
 	private string getAPIURLPrefix()


### PR DESCRIPTION
GitLab has updated its API to download the repository archive, so it causes the issue because it could not download the requested repository

Updating the generation of the URL (https://docs.gitlab.com/ee/api/repositories.html#get-file-archive) with the new API is enough to solve the problem

To test: https://salty-hamlet-35363.herokuapp.com/packages/gitlab-test-package/1.0.0.zip