### PR TITLE
Work around a stack corruption causing broken GitLab downloads

### DIFF
--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -136,7 +136,7 @@ class DbController {
 	{
 		auto pack = m_packages.findOne!DbPackage(["name": packname]);
 		enforce!RecordNotFound(!pack.isNull(), "Unknown package name.");
-		return pack;
+		return pack.get;
 	}
 
 	auto getPackages(scope string[] packnames...)
@@ -156,7 +156,7 @@ class DbController {
 	{
 		auto pack = m_packages.findOne!DbPackage(["_id": id]);
 		enforce!RecordNotFound(!pack.isNull(), "Unknown package ID.");
-		return pack;
+		return pack.get;
 	}
 
 	auto getAllPackages()


### PR DESCRIPTION
Returning the `Nullable!DbPackage`, implicitly converted to `DbPackage`, triggered a codegen issue on LDC, leading to the version string to become empty on Windows and causing a crash on the following method call on Linux.

Closes #436. Fixes #349.