### PR TITLE
Fixed GitLab private repositories download file URL

### DIFF
--- a/source/dubregistry/repositories/gitlab.d
+++ b/source/dubregistry/repositories/gitlab.d
@@ -123,7 +123,7 @@ class GitLabRepository : Repository {
 	void readFile(string commit_sha, InetPath path, scope void delegate(scope InputStream) @safe reader)
 	{
 		assert(path.absolute, "Passed relative path to readFile.");
-		auto url = m_baseURL.toString() ~ (m_owner ~ "/" ~ m_projectPath ~ "/raw/" ~ commit_sha) ~ path.toString() ~ "?private_token="~m_authToken;
+		auto url = getAPIURLPrefix() ~ "repository/files/" ~ path.toString().urlEncode ~ "/raw?ref=" ~ commit_sha ~ "&private_token="~ m_authToken;
 		downloadCached(url, (scope input) {
 			reader(input);
 		}, true);


### PR DESCRIPTION
Currently GitLab support is broken for private repositories.
see: https://gitlab.com/gitlab-org/gitlab-foss/issues/55081

This commit makes dub-registry use GitLab api thus fixing private repository browsing