### PR TITLE
Fix #456: Missing tags when a project has more than 100 tags

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -9,6 +9,7 @@ license "BSL-1.0"
 dependency "vibe-d" version="~>0.9.0-beta.1"
 dependency "dub" version="~>1.25.0"
 dependency "userman" version="~>0.4.0"
+dependency "uritemplate" version="~>1.0.0"
 subConfiguration "dub" "library-nonet"
 
 versions "VibeJsonFieldNames"

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -15,6 +15,7 @@
 		"openssl": "1.1.6+1.0.1g",
 		"stdx-allocator": "2.77.5",
 		"taggedalgebraic": "0.11.21",
+		"uritemplate": "1.0.0",
 		"userman": "0.4.1+commit.1.ged5ea95",
 		"vibe-core": "1.16.0",
 		"vibe-d": "0.9.3+commit.2.g77632176"


### PR DESCRIPTION
* adds a template URI parser for the Link header in GitHub (and also other parts) where it says it may use Hypermedia links in uritemplate.d - I will release this file as separate MIT library as well, so instead of including it here it might also be worth it just depending on it
* adds the possibility to cache headers in the urlcache module
* adds the readPagedList function in GitHub which traverses the list

For #456 to be properly fixed in this exact case right after deployment, either a new ETag must be sent by github (which is probably done on next release) or the db.urlcache.entries in vpmreg needs to be dropped by a DB administrator (s-ludwig) and all URLs should automatically be regrabbed. I think doing the latter will prevent some pain as cache may be cached for up to a year and I'm not exactly sure when GitHub will send new ETag values.

On localhost this fix now made mir-algorithm have 332 versions instead of 114 (100 tags + branches) again.