### PR TITLE
Replace travis-ci link from .org to .com

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ DUB registry
 
 ![vibe.d logo](public/images/logo-small.png) Online registry for [dub](https://github.com/dlang/dub/) packages, see <http://code.dlang.org/>.
 
-[![Build Status](https://travis-ci.org/dlang/dub-registry.svg)](https://travis-ci.org/dlang/dub-registry)
+[![Build Status](https://travis-ci.com/dlang/dub-registry.svg)](https://travis-ci.com/dlang/dub-registry)
 
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://www.heroku.com/deploy?template=https://github.com/dlang/dub-registry)
 


### PR DESCRIPTION
The repository was migrated and the links need to be updated.