### PR TITLE
Enable partial search

### DIFF
--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -331,7 +331,7 @@ class DbController {
 		}
 
 		auto pkgs = m_packages
-			.find(["$text": ["$search": query]], ["textScore": bson(["$meta": "textScore"])])
+			.find(["$text": ["$search": "/" ~ query ~ "/i"]], ["textScore": bson(["$meta": "textScore"])])
 			.sort(["textScore": bson(["$meta": "textScore"])]) // sort to only keep most relevant results
 			.limit(50) // limit irrelevant sort results (fixes #341)
 			.map!(deserializeBson!DbPackage)


### PR DESCRIPTION
**Problem**
When searching for packages, partial maches are not found.

**Example**
Search for "jwt" on dub.pm -> https://code.dlang.org/search?q=jwt

**Result**
Does not find jwtd, only jwt

**Proposed solution**
Use partial search by changing query

**Possible alternative solution**
Configure partial search

**Possible alternative solution 2**
Enable usage of wildcard operator

**NOTE**
Untested solution