### PR TITLE
Fix link to page explaining how to publish

### DIFF
--- a/source/dubregistry/web.d
+++ b/source/dubregistry/web.d
@@ -483,7 +483,7 @@ class DubRegistryFullWebFrontend : DubRegistryWebFrontend {
 	void getUsage() { getGettingStarted(); }
 	void getAdvancedUsage() { redirect("https://dub.pm/getting_started"); }
 
-	void getPublish() { redirect("https://dub.pm/commandline"); }
+	void getPublish() { redirect("https://dub.pm/publish"); }
 	void getDevelop() { redirect("https://dub.pm/commandline"); }
 
 	@path("/package-format")


### PR DESCRIPTION
I noticed that the "Learn more about publishing" links redirect to the Command Line Usage page on dub.pm, instead of the actual publishing page.

