### PR TITLE
Fix GitLab readFile()

### DIFF
--- a/source/dubregistry/repositories/gitlab.d
+++ b/source/dubregistry/repositories/gitlab.d
@@ -123,7 +123,8 @@ class GitLabRepository : Repository {
 	void readFile(string commit_sha, InetPath path, scope void delegate(scope InputStream) @safe reader)
 	{
 		assert(path.absolute, "Passed relative path to readFile.");
-		auto url = getAPIURLPrefix() ~ "repository/files/" ~ path.toString().urlEncode ~ "/raw?ref=" ~ commit_sha ~ "&private_token="~ m_authToken;
+		auto penc = path.toString()[1..$].urlEncode;
+		auto url = getAPIURLPrefix() ~ "repository/files/" ~ penc ~ "/raw?ref=" ~ commit_sha ~ "&private_token="~ m_authToken;
 		downloadCached(url, (scope input) {
 			reader(input);
 		}, true);


### PR DESCRIPTION
The GitLab API started rejecting paths starting with /

https://gitlab.com/gitlab-org/gitlab/-/issues/212216

Fixes https://github.com/dlang/dub-registry/issues/471