### PR TITLE
add 'WebAssembly compatible' category

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -61,6 +61,7 @@
 			{"name": "vcs", "description": "Version control"},
 			{"name": "video", "description": "Video libraries"},
 			{"name": "vibed", "description": "vibe.d compatible library"},
+			{"name": "wasm", "description": "WebAssembly compatible"},
 			{"name": "web", "description": "Web related", "categories": [
 				{"name": "auth", "description": "Authentication and user management"},
 				{"name": "communication", "description": "Communication components"},


### PR DESCRIPTION
adds a category which can be used to indicate that libraries are written in a WebAssembly compatible way or written for WebAssembly specifically (like Web API wrappers or entire standard library implementations for the web)

Maybe if there are possible standard formats to generate the glue code from D to JS/WASM or define the exports, this category additionally helps with finding these.