### PR TITLE
Add BetterC category

### DIFF
--- a/categories.json
+++ b/categories.json
@@ -36,6 +36,7 @@
 		{"name": "library", "description": "Development library", "categories": [
 			{"name": "std_aspirant", "description": "Candidate for inclusion in the D standard library"},
 			{"name": "audio", "description": "Audio libraries"},
+			{"name": "betterc", "description": "BetterC compatible"},
 			{"name": "binding", "description": "D language bindings", "categories": [
 				{"name": "deimos", "description": "Deimos header-only binding"}
 			]},


### PR DESCRIPTION
There are currently 38 packages mentioning `-betterC` support in the description, and an unknown number of packages supporting `-betterC` not mentioned in the description. Adding a category for it could make it easier to find them once package maintainers apply it appropriately.