### PR TITLE
Ensure fair package updates and fix queue overflow

### DIFF
--- a/dub.sdl
+++ b/dub.sdl
@@ -7,7 +7,7 @@ authors "Sönke Ludwig" "Martin Nowak" "Anton Fediushin aka ohdatboi" \
 license "BSL-1.0"
 
 dependency "vibe-d" version="~>0.9.0-beta.1"
-dependency "dub" version="~>1.21.0"
+dependency "dub" version="~>1.25.0"
 dependency "userman" version="~>0.4.0"
 subConfiguration "dub" "library-nonet"
 

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -2,11 +2,11 @@
 	"fileVersion": 1,
 	"versions": {
 		"backtrace-d": "~master",
-		"botan": "1.12.18",
+		"botan": "1.12.19",
 		"botan-math": "1.0.3",
-		"diet-ng": "1.7.4",
-		"dub": "1.21.0",
-		"eventcore": "0.9.10",
+		"diet-ng": "1.7.5",
+		"dub": "1.25.0",
+		"eventcore": "0.9.13",
 		"libasync": "0.8.6",
 		"libev": "5.0.0+4.04",
 		"libevent": "2.0.2+2.0.16",
@@ -14,9 +14,9 @@
 		"mir-linux-kernel": "1.0.1",
 		"openssl": "1.1.6+1.0.1g",
 		"stdx-allocator": "2.77.5",
-		"taggedalgebraic": "0.11.18",
+		"taggedalgebraic": "0.11.21",
 		"userman": "0.4.1+commit.1.ged5ea95",
-		"vibe-core": "1.11.0",
-		"vibe-d": "0.9.2"
+		"vibe-core": "1.16.0",
+		"vibe-d": "0.9.3+commit.2.g77632176"
 	}
 }

--- a/source/app.d
+++ b/source/app.d
@@ -148,6 +148,10 @@ struct AppConfig
 void main()
 {
 	bool noMonitoring, noServe;
+
+	import std.random : rndGen, unpredictableSeed;
+	rndGen.seed(unpredictableSeed);
+
 	setLogFile("log.txt", LogLevel.diagnostic);
 
 	version (linux) version (DMD)

--- a/source/dubregistry/registry.d
+++ b/source/dubregistry/registry.d
@@ -444,7 +444,8 @@ class DubRegistry {
 		auto allpacks = this.availablePackages.array;
 		randomShuffle(allpacks);
 		foreach (packname; allpacks)
-			triggerPackageUpdate(packname);
+			if (!m_updateQueue.isPending(packname))
+				triggerPackageUpdate(packname);
 	}
 
 	protected string validateRepository(DbRepository repository)

--- a/source/dubregistry/registry.d
+++ b/source/dubregistry/registry.d
@@ -431,10 +431,19 @@ class DubRegistry {
 
 	void updatePackages()
 	{
+		import std.random : randomShuffle;
+
 		logDiagnostic("Triggering package update...");
 		// update stat distributions before score packages
 		m_statDistributions = m_db.getStatDistributions();
-		foreach (packname; this.availablePackages)
+
+		// shuffle the package list to ensure a uniform probability of each
+		// package getting chosen over time, regardless of how long it takes
+		// to process the whole list and whether the process gets restarted
+		// in-between
+		auto allpacks = this.availablePackages.array;
+		randomShuffle(allpacks);
+		foreach (packname; allpacks)
 			triggerPackageUpdate(packname);
 	}
 


### PR DESCRIPTION
There were several issues playing together here, resulting in some packages never getting updated:

- The periodic package update was scheduling packages redundantly, combined with an update cycle that is nowadays longer than the anticipated 30 minutes, this resulted in the back part of the package list never being reached
- The secondary consequence was that the process crashed at some point with an assertion due to the update queue filling up, resulting in another possible reason for the package list to never be fully processed
- Packages were always inserted into the queue in the same order - now they are randomized, resulting in a natural robustness against similar issues

See also dlang/dub#2128 and #495.