### PR TITLE
make dpldocs links versioned instead of master

### DIFF
--- a/views/view_package.dt
+++ b/views/view_package.dt
@@ -3,6 +3,7 @@ extends layout
 block title
 	- import std.algorithm;
 	- import std.array : join, split;
+	- import std.conv : text;
 	- import std.range;
 	- import vibe.data.json;
 	- import vibe.inet.url;
@@ -109,7 +110,7 @@ block body
 			- foreach (i, sample; sampleURLs)
 				a.tab(class=activeTab == "sample_"~i.to!string ? "active" : "", href="#{req.rootDir}packages/#{normalizedPackageName}?tab=sample_#{i}")= sample
 			- auto doc_url = packinfo.info["documentationURL"].get!string;
-			- doc_url = !doc_url.empty ? doc_url : "https://"~normalizedPackageName~".dpldocs.info";
+			- doc_url = !doc_url.empty ? doc_url : text("https://",normalizedPackageName,".dpldocs.info/",versionInfo["version"].get!string,"/");
 			a.tab.external(href="#{doc_url}", target="_blank") Documentation
 		- bool renderedTabContent;
 		- if (activeTab == "info")


### PR DESCRIPTION
This fixes that you need to keep reloading the cache to see updated documentation and allows you to view documentation of older versions.