### PR TITLE
fix ellipse on start page not displaying properly

### DIFF
--- a/views/start.dt
+++ b/views/start.dt
@@ -58,7 +58,10 @@ block body
 							.dub-package-name
 								a(href='packages/#{pl["name"].get!string}')= pl["name"].get!string
 							.dub-package-version
-								| #{ ver.length <= 20 ? ver : ver[0 .. 18] ~ "&hellip;" }
+								- if (ver.length <= 20)
+									|= ver
+								- else
+									| #{ver[0 .. 18]}&hellip;
 							.dub-package-desc
 								|= desc
 							.dub-package-author


### PR DESCRIPTION
Making it part of the string makes diet escape the special ampersand character. If we would insert raw HTML here we could introduce issues with HTML injection, so doing it the verbose way fixes it the easiest.

Might probably want to make this some global function instead of copy-pasting this code everywhere, but fixes the issue for now.

Fixes this on the start page:

![grafik](https://user-images.githubusercontent.com/2035977/126657513-1f1fa723-3d83-4390-bdb8-9155d32bc26d.png)
