### PR TITLE
fix README settings.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ You can do so by creating a `settings.json` in the root folder of the dub-regist
 
 ```json
 {
-	"github-user": "<github-user-name>",
-	"github-password": "<github-personal-access-token from https://github.com/settings/tokens>",
+	"github-auth": "<github-personal-access-token from https://github.com/settings/tokens>",
 	"gitlab-url": "https://gitlab.com/",
 	"gitlab-auth": "<gitlab-api-token from https://gitlab.com/profile/personal_access_tokens>",
 	"bitbucket-user": "<your-fancy-user-name>",


### PR DESCRIPTION
github-username and password no longer exist for deployment!

See https://github.com/dlang/dub-registry/blob/a13c0b87efd5c59be2b9bfb58cebe604b2e8d2b1/source/app.d#L118