### PR TITLE
rename documentation to reference

### DIFF
--- a/views/view_package.dt
+++ b/views/view_package.dt
@@ -110,8 +110,9 @@ block body
 			- foreach (i, sample; sampleURLs)
 				a.tab(class=activeTab == "sample_"~i.to!string ? "active" : "", href="#{req.rootDir}packages/#{normalizedPackageName}?tab=sample_#{i}")= sample
 			- auto doc_url = packinfo.info["documentationURL"].get!string;
-			- doc_url = !doc_url.empty ? doc_url : text("https://",normalizedPackageName,".dpldocs.info/",versionInfo["version"].get!string,"/");
-			a.tab.external(href="#{doc_url}", target="_blank") Documentation
+			- if (doc_url.length)
+				a.tab.external(href=doc_url, target="_blank") Documentation
+			a.tab.external(href=text("https://",normalizedPackageName,".dpldocs.info/",versionInfo["version"].get!string,"/"), target="_blank") Reference
 		- bool renderedTabContent;
 		- if (activeTab == "info")
 			- if (readmeContents.length)


### PR DESCRIPTION
Always show custom documentation tab separately.

This makes it so that it's clear that the dpldocs link is most likely
just a code reference for all the code and the separate
documentation page that can be configured in the package config will be
shown as separate button.

Preview when custom documentation page is set:

![readme, documentation, reference](https://wfr.moe/f6uLa2.png)

Preview when custom documentation page is not set:

![readme, reference](https://wfr.moe/f6ucVP.png)