### PR TITLE
dbcontroller: Remove old migration code

### DIFF
--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -38,9 +38,6 @@ class DbController {
 		// migrations:
 		//
 
-		// remove old logo fields
-		m_packages.update(["logoHash": ["$exists": true]], ["$unset": ["logo": 0, "logoHash": 0]], UpdateFlags.multiUpdate);
-
 		// create indices
 		m_packages.ensureIndex([tuple("name", 1)], IndexFlags.Unique);
 		m_packages.ensureIndex([tuple("stats.score", 1)]);

--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -43,10 +43,6 @@ class DbController {
 		m_packages.ensureIndex([tuple("stats.score", 1)]);
 		m_downloads.ensureIndex([tuple("package", 1), tuple("version", 1)]);
 
-		// drop old text index versions
-		db.runCommand(["dropIndexes": "packages", "index": "packages_full_text_search_index"]);
-		db.runCommand(["dropIndexes": "packages", "index": "packages_full_text_search_index_v2"]);
-
 		// add current text index
 		immutable keyWeights = [
 			"name": 8,

--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -38,17 +38,6 @@ class DbController {
 		// migrations:
 		//
 
-		// add default non-@optional stats to packages
-		DbPackageStats stats;
-		m_packages.update(["stats": ["$exists": false]], ["$set": ["stats": stats]], UpdateFlags.multiUpdate);
-
-		// rename stats.rating -> stats.score
-		m_packages.update(Bson.emptyObject(), ["$rename": ["stats.rating": "stats.score"]], UpdateFlags.multiUpdate);
-
-		// default initialize missing scores with zero
-		float score = 0;
-		m_packages.update(["stats.score": ["$exists": false]], ["$set": ["stats.score": score]], UpdateFlags.multiUpdate);
-
 		// remove old logo fields
 		m_packages.update(["logoHash": ["$exists": true]], ["$unset": ["logo": 0, "logoHash": 0]], UpdateFlags.multiUpdate);
 


### PR DESCRIPTION
Was looking at adding a migration myself, and obviously there is a bit of legacy that we can (and should) clean up first.