### PR TITLE
Upgrade submodules (vibe-d, vibe-core, eventcore, userman)

### DIFF
--- a/dub.selections.json
+++ b/dub.selections.json
@@ -6,7 +6,7 @@
 		"botan-math": "1.0.3",
 		"diet-ng": "1.8.1",
 		"dub": "1.29.2",
-		"eventcore": "0.9.23",
+		"eventcore": "0.9.25",
 		"libasync": "0.8.6",
 		"libev": "5.0.0+4.04",
 		"libevent": "2.0.2+2.0.16",
@@ -17,8 +17,8 @@
 		"stdx-allocator": "2.77.5",
 		"taggedalgebraic": "0.11.22",
 		"uritemplate": "1.0.0",
-		"userman": "0.4.1",
-		"vibe-core": "1.23.0",
-		"vibe-d": "0.9.5"
+		"userman": "0.4.2",
+		"vibe-core": "2.2.0",
+		"vibe-d": "0.9.6"
 	}
 }

--- a/source/dubregistry/internal/workqueue.d
+++ b/source/dubregistry/internal/workqueue.d
@@ -124,8 +124,11 @@ unittest {
 		sleep(100.msecs);
 	}
 
-	void test()
+	void test() @safe nothrow
 	{
+        // `runTask` expect a `nothrow` delegate but this class is not
+        // because _d_monitorenter & co are not nothrow.
+        scope (failure) assert(0, "Test has thrown");
 		auto q = new PackageWorkQueue(&handler);
 		assert(!q.isPending("foo"));
 		assert(!q.isPending("bar"));


### PR DESCRIPTION
So that dub-registry compiles with the latest version of DMD.