### PR TITLE
add error logging on DB errors

### DIFF
--- a/source/dubregistry/registry.d
+++ b/source/dubregistry/registry.d
@@ -219,7 +219,11 @@ class DubRegistry {
 	{
 		DbPackage pack;
 		try pack = m_db.getPackage(packname);
-		catch(Exception) return PackageInfo.init;
+		catch (RecordNotFound) return PackageInfo.init;
+		catch (Exception e) {
+			logError("Unexpected Exception when calling db.getPackage: %s", (() @trusted => e.toString())());
+			return PackageInfo.init;
+		}
 
 		return getPackageInfo(pack, flags);
 	}


### PR DESCRIPTION
keep quiet when it's just package not found, but otherwise log error

This will introduce logs for when DB requests fail, as well as when deserialization fails for some reason.