### PR TITLE
Add Gitea support

### DIFF
--- a/dub.selections.json
+++ b/dub.selections.json
@@ -5,20 +5,20 @@
 		"botan": "1.12.19",
 		"botan-math": "1.0.3",
 		"diet-ng": "1.8.1",
-		"dub": "1.33.0",
-		"eventcore": "0.9.25",
+		"dub": "1.33.1",
+		"eventcore": "0.9.26",
 		"libasync": "0.8.6",
 		"libev": "5.0.0+4.04",
 		"libevent": "2.0.2+2.0.16",
 		"memutils": "1.0.9",
 		"mir-linux-kernel": "1.0.1",
-		"openssl": "3.3.0",
+		"openssl": "3.3.3",
 		"openssl-static": "1.0.2+3.0.8",
 		"stdx-allocator": "2.77.5",
 		"taggedalgebraic": "0.11.22",
 		"uritemplate": "1.0.0",
 		"userman": "0.4.2",
-		"vibe-core": "2.2.0",
-		"vibe-d": "0.9.7-alpha.3"
+		"vibe-core": "2.2.1",
+		"vibe-d": "0.9.7"
 	}
 }

--- a/source/app.d
+++ b/source/app.d
@@ -129,9 +129,9 @@ void main()
 		}
 	}
 
-	GithubRepository.register(appConfig.ghauth);
-	BitbucketRepository.register(appConfig.bbuser, appConfig.bbpassword);
-	if (appConfig.glurl.length) GitLabRepository.register(appConfig.glauth, appConfig.glurl);
+	GithubRepositoryProvider.register(appConfig.ghauth);
+	BitbucketRepositoryProvider.register(appConfig.bbuser, appConfig.bbpassword);
+	if (appConfig.glurl.length) GitLabRepositoryProvider.register(appConfig.glauth, appConfig.glurl);
 
 	auto router = new URLRouter;
 	if (s_mirror.length) router.any("*", (req, res) { req.params["mirror"] = s_mirror; });

--- a/source/app.d
+++ b/source/app.d
@@ -65,6 +65,8 @@ version (linux) {
 // generate dummy data for e.g. Heroku's preview apps
 void defaultInit(UserManController userMan, DubRegistry registry)
 {
+	import dubregistry.repositories.repository : parseRepositoryURL;
+
 	if (environment.get("GENERATE_DEFAULT_DATA", "0") == "1" &&
 		registry.getPackageDump().empty && userMan.getUserCount() == 0)
 	{
@@ -81,7 +83,7 @@ void defaultInit(UserManController userMan, DubRegistry registry)
 		foreach (url; packages)
 		{
 			DbRepository repo;
-			repo.parseURL(URL(url));
+			parseRepositoryURL(URL(url), repo);
 			registry.addPackage(repo, userId);
 		}
 	}

--- a/source/app.d
+++ b/source/app.d
@@ -10,6 +10,7 @@ import dubregistry.mirror;
 import dubregistry.repositories.bitbucket;
 import dubregistry.repositories.github;
 import dubregistry.repositories.gitlab;
+import dubregistry.repositories.gitea;
 import dubregistry.registry;
 import dubregistry.web;
 import dubregistry.api;
@@ -134,6 +135,7 @@ void main()
 	GithubRepositoryProvider.register(appConfig.ghauth);
 	BitbucketRepositoryProvider.register(appConfig.bbuser, appConfig.bbpassword);
 	if (appConfig.glurl.length) GitLabRepositoryProvider.register(appConfig.glauth, appConfig.glurl);
+	if (appConfig.giteaurl.length) GiteaRepositoryProvider.register(appConfig.giteaauth, appConfig.giteaurl);
 
 	auto router = new URLRouter;
 	if (s_mirror.length) router.any("*", (req, res) { req.params["mirror"] = s_mirror; });

--- a/source/dubregistry/config.d
+++ b/source/dubregistry/config.d
@@ -28,6 +28,10 @@ public struct AppConfig
 	string bbuser;
 	@Name("bitbucket-password") @Optional
 	string bbpassword;
+	@Name("gitea-url") @Optional
+	string giteaurl;
+	@Name("gitea-auth") @Optional
+	string giteaauth;
 	@Name("enforce-certificate-trust")
 	bool enforceCertificateTrust = false;
 

--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -144,7 +144,7 @@ class DbController {
 	{
 		static struct PO {
 			BsonObjectID owner;
-			DbPackage.SharedUser[] sharedUsers;
+			@optional DbPackage.SharedUser[] sharedUsers;
 		}
 
 		auto p = m_packages.findOne!PO(["name": package_name], ["owner": 1, "sharedUsers": 1]);

--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -543,56 +543,6 @@ struct DbRepository {
 	string kind;
 	string owner;
 	string project;
-
-	void parseURL(URL url)
-	{
-		string host = url.host;
-		if (!url.schema.among!("http", "https"))
-			throw new Exception("Invalid Repository Schema (only supports http and https)");
-		if (host.endsWith(".github.com") || host == "github.com" || host == "github") {
-			kind = "github";
-		} else if (host.endsWith(".gitlab.com") || host == "gitlab.com" || host == "gitlab") {
-			kind = "gitlab";
-		} else if (host.endsWith(".bitbucket.org") || host == "bitbucket.org" || host == "bitbucket") {
-			kind = "bitbucket";
-		} else {
-			throw new Exception("Please input a valid project URL to a GitHub, GitLab or BitBucket project.");
-		}
-		auto path = url.path.relativeTo(InetPath("/")).bySegment;
-		if (path.empty)
-			throw new Exception("Invalid Repository URL (no path)");
-		if (path.empty || path.front.name.empty)
-			throw new Exception("Invalid Repository URL (missing owner)");
-		owner = path.front.name.to!string;
-		path.popFront;
-		if (path.empty || path.front.name.empty)
-			throw new Exception("Invalid Repository URL (missing project)");
-
-		if(kind == "gitlab")  // Allow any number of segments, as GitLab's subgroups can be nested
-			project = path.map!"a.name".join("/");
-		else
-			project = path.front.name.to!string;
-		path.popFront;
-		if (!path.empty && kind != "gitlab")
-			throw new Exception("Invalid Repository URL (got more than owner and project)");
-	}
-
-	unittest {
-		DbRepository r;
-		r.parseURL(URL("https://github.com/foo/bar"));
-		assert(r == DbRepository("github", "foo", "bar"));
-		r.parseURL(URL("http://bitbucket.org/bar/baz/"));
-		assert(r == DbRepository("bitbucket", "bar", "baz"));
-		r.parseURL(URL("https://gitlab.com/foo/bar"));
-		assert(r == DbRepository("gitlab", "foo", "bar"));
-		r.parseURL(URL("https://gitlab.com/group/subgroup/subsubgroup/project"));
-		assert(r == DbRepository("gitlab", "group", "subgroup/subsubgroup/project"));
-		assertThrown(r.parseURL(URL("ftp://github.com/foo/bar")));
-		assertThrown(r.parseURL(URL("ftp://github.com/foo/bar")));
-		assertThrown(r.parseURL(URL("http://github.com/foo/")));
-		assertThrown(r.parseURL(URL("http://github.com/")));
-		assertThrown(r.parseURL(URL("http://github.com/foo/bar/baz")));
-	}
 }
 
 struct DbPackageFile {

--- a/source/dubregistry/repositories/bitbucket.d
+++ b/source/dubregistry/repositories/bitbucket.d
@@ -16,6 +16,27 @@ import vibe.core.stream;
 import vibe.data.json;
 import vibe.inet.url;
 
+class BitbucketRepositoryProvider : RepositoryProvider {
+	private {
+		string m_user, m_password;
+	}
+@safe:
+	private this(string user, string password)
+	{
+		m_user = user;
+		m_password = password;
+	}
+
+	static void register(string user, string password)
+	{
+		addRepositoryProvider("bitbucket", new BitbucketRepositoryProvider(user, password));
+	}
+
+	Repository getRepository(DbRepository repo)
+	@safe {
+		return new BitbucketRepository(repo.owner, repo.project, m_user, m_password);
+	}
+}
 
 class BitbucketRepository : Repository {
 @safe:
@@ -25,14 +46,6 @@ class BitbucketRepository : Repository {
 		string m_project;
 		string m_authUser;
 		string m_authPassword;
-	}
-
-	static void register(string user, string password)
-	{
-		Repository factory(DbRepository info) @safe {
-			return new BitbucketRepository(info.owner, info.project, user, password);
-		}
-		addRepositoryFactory("bitbucket", &factory);
 	}
 
 	this(string owner, string project, string auth_user, string auth_password)

--- a/source/dubregistry/repositories/bitbucket.d
+++ b/source/dubregistry/repositories/bitbucket.d
@@ -32,6 +32,48 @@ class BitbucketRepositoryProvider : RepositoryProvider {
 		addRepositoryProvider("bitbucket", new BitbucketRepositoryProvider(user, password));
 	}
 
+	bool parseRepositoryURL(URL url, out DbRepository repo)
+	@safe {
+		import std.algorithm.searching : endsWith;
+		import std.conv : to;
+
+		string host = url.host;
+		if (!host.endsWith(".bitbucket.org") && host != "bitbucket.org" && host != "bitbucket")
+			return false;
+
+		repo.kind = "bitbucket";
+
+		auto path = url.path.relativeTo(InetPath("/")).bySegment;
+		if (path.empty)
+			throw new Exception("Invalid Repository URL (no path)");
+		if (path.front.name.empty)
+			throw new Exception("Invalid Repository URL (missing owner)");
+		repo.owner = path.front.name.to!string;
+		path.popFront;
+		if (path.empty || path.front.name.empty)
+			throw new Exception("Invalid Repository URL (missing project)");
+
+		repo.project = path.front.name.to!string;
+		path.popFront;
+		if (!path.empty)
+			throw new Exception("Invalid Repository URL (got more than owner and project)");
+
+		return true;
+	}
+
+	unittest {
+		import std.exception : assertThrown;
+
+		auto h = new BitbucketRepositoryProvider(null, null);
+		DbRepository r;
+		assert(!h.parseRepositoryURL(URL("https://github.com/foo/bar"), r));
+		assert(h.parseRepositoryURL(URL("http://bitbucket.org/bar/baz/"), r));
+		assert(r == DbRepository("bitbucket", "bar", "baz"));
+		assertThrown(h.parseRepositoryURL(URL("http://bitbucket.org/foo/"), r));
+		assertThrown(h.parseRepositoryURL(URL("http://bitbucket.org/"), r));
+		assertThrown(h.parseRepositoryURL(URL("http://bitbucket.org/foo/bar/baz"), r));
+	}
+
 	Repository getRepository(DbRepository repo)
 	@safe {
 		return new BitbucketRepository(repo.owner, repo.project, m_user, m_password);

--- a/source/dubregistry/repositories/gitea.d
+++ b/source/dubregistry/repositories/gitea.d
@@ -41,7 +41,7 @@ class GiteaRepositoryProvider : RepositoryProvider {
 		import std.conv : to;
 
 		string host = url.host;
-		if (!url.startsWith(URL(m_url)) && !host.endsWith(".gitea.com") && host != "gitea.com" && host != "gitea")
+		if (!url.startsWith(URL(m_url)))
 			return false;
 
 		repo.kind = "gitea";
@@ -70,12 +70,12 @@ class GiteaRepositoryProvider : RepositoryProvider {
 		DbRepository r;
 		assert(h.parseRepositoryURL(URL("https://example.org/foo/bar"), r));
 		assert(r == DbRepository("gitea", "foo", "bar"));
-		assert(h.parseRepositoryURL(URL("https://gitea.com/foo/bar"), r));
+		assert(h.parseRepositoryURL(URL("https://example.org/foo/bar"), r));
 		assert(r == DbRepository("gitea", "foo", "bar"));
 		assert(!h.parseRepositoryURL(URL("http://bitbucket.org/bar/baz/"), r));
-		assertThrown(h.parseRepositoryURL(URL("http://gitea.com/foo/"), r));
-		assertThrown(h.parseRepositoryURL(URL("http://gitea.com/"), r));
-		assertThrown(h.parseRepositoryURL(URL("http://gitea.com/foo/bar/baz"), r));
+		assertThrown(h.parseRepositoryURL(URL("https://example.org/foo/"), r));
+		assertThrown(h.parseRepositoryURL(URL("https://example.org/"), r));
+		assertThrown(h.parseRepositoryURL(URL("https://example.org/foo/bar/baz"), r));
 	}
 
 	Repository getRepository(DbRepository repo)

--- a/source/dubregistry/repositories/gitea.d
+++ b/source/dubregistry/repositories/gitea.d
@@ -1,0 +1,284 @@
+/**
+	Copyright: © 2023 Sönke Ludwig
+	License: Subject to the terms of the GNU GPLv3 license, as written in the included LICENSE.txt file.
+	Authors: Sönke Ludwig
+*/
+module dubregistry.repositories.gitea;
+
+import dubregistry.cache;
+import dubregistry.dbcontroller : DbRepository;
+import dubregistry.repositories.repository;
+import std.string : startsWith;
+import std.typecons;
+import vibe.core.log;
+import vibe.core.stream;
+import vibe.data.json;
+import vibe.http.client : HTTPClientRequest;
+import vibe.inet.url;
+
+class GiteaRepositoryProvider : RepositoryProvider {
+	private {
+		string m_token;
+		string m_url;
+	}
+@safe:
+
+	private this(string token, string url)
+	{
+		m_token = token;
+		m_url = url.length ? url : "https://gitea.com/";
+	}
+
+	static void register(string token, string url)
+	{
+		auto h = new GiteaRepositoryProvider(token, url);
+		addRepositoryProvider("gitea", h);
+	}
+
+	bool parseRepositoryURL(URL url, out DbRepository repo)
+	@safe {
+		import std.algorithm.searching : endsWith;
+		import std.conv : to;
+
+		string host = url.host;
+		if (!url.startsWith(URL(m_url)) && !host.endsWith(".gitea.com") && host != "gitea.com" && host != "gitea")
+			return false;
+
+		repo.kind = "gitea";
+
+		auto path = url.path.relativeTo(InetPath("/")).bySegment;
+
+		if (path.empty) throw new Exception("Invalid Repository URL (no path)");
+		if (path.front.name.empty) throw new Exception("Invalid Repository URL (missing owner)");
+		repo.owner = path.front.name.to!string;
+		path.popFront;
+
+		if (path.empty || path.front.name.empty)
+			throw new Exception("Invalid Repository URL (missing project)");
+		repo.project = path.front.name.to!string;
+		path.popFront;
+
+		if (!path.empty) throw new Exception("Invalid Repository URL (got more than owner and project)");
+
+		return true;
+	}
+
+	unittest {
+		import std.exception : assertThrown;
+
+		auto h = new GiteaRepositoryProvider(null, "https://example.org");
+		DbRepository r;
+		assert(h.parseRepositoryURL(URL("https://example.org/foo/bar"), r));
+		assert(r == DbRepository("gitea", "foo", "bar"));
+		assert(h.parseRepositoryURL(URL("https://gitea.com/foo/bar"), r));
+		assert(r == DbRepository("gitea", "foo", "bar"));
+		assert(!h.parseRepositoryURL(URL("http://bitbucket.org/bar/baz/"), r));
+		assertThrown(h.parseRepositoryURL(URL("http://gitea.com/foo/"), r));
+		assertThrown(h.parseRepositoryURL(URL("http://gitea.com/"), r));
+		assertThrown(h.parseRepositoryURL(URL("http://gitea.com/foo/bar/baz"), r));
+	}
+
+	Repository getRepository(DbRepository repo)
+	@safe {
+		return new GiteaRepository(repo.owner, repo.project, m_token, m_url);
+	}
+}
+
+
+class GiteaRepository : Repository {
+@safe:
+	private {
+		string m_owner;
+		string m_project;
+		string m_authToken;
+		string m_url;
+	}
+
+	this(string owner, string project, string auth_token, string url)
+	{
+		assert(url.length > 0, "Missing URL for Gitea repository");
+
+		m_owner = owner;
+		m_project = project;
+		m_authToken = auth_token;
+		m_url = url;
+		if (m_url[$-1] != '/') m_url ~= "/";
+	}
+
+	RefInfo[] getTags()
+	{
+		import std.datetime.systime : SysTime;
+		import std.conv: text;
+		RefInfo[] ret;
+		Json[] tags;
+		try tags = readPagedListFromRepo("/tags?per_page=100");
+		catch( Exception e ) { throw new Exception("Failed to get tags: "~e.msg); }
+		foreach_reverse (tag; tags) {
+			try {
+				auto tagname = tag["name"].get!string;
+				Json commit = readJsonFromRepo("/commits/"~tag["commit"]["sha"].get!string~"/status", true, true);
+				ret ~= RefInfo(tagname, tag["commit"]["sha"].get!string, SysTime.fromISOExtString(commit["statuses"][0]["created_at"].get!string));
+				logDebug("Found tag for %s/%s: %s", m_owner, m_project, tagname);
+			} catch( Exception e ){
+				throw new Exception("Failed to process tag "~tag["name"].get!string~": "~e.msg);
+			}
+		}
+		return ret;
+	}
+
+	RefInfo[] getBranches()
+	{
+		import std.datetime.systime : SysTime;
+
+		Json branches = readJsonFromRepo("/branches");
+		RefInfo[] ret;
+		foreach_reverse( branch; branches ){
+			auto branchname = branch["name"].get!string;
+			Json commit = readJsonFromRepo("/commits/"~branch["commit"]["id"].get!string~"/status", true, true);
+			ret ~= RefInfo(branchname, branch["commit"]["id"].get!string, SysTime.fromISOExtString(commit["statuses"][0]["created_at"].get!string));
+			logDebug("Found branch for %s/%s: %s", m_owner, m_project, branchname);
+		}
+		return ret;
+	}
+
+	RepositoryInfo getInfo()
+	{
+		auto nfo = readJsonFromRepo("");
+		RepositoryInfo ret;
+		ret.isFork = nfo["fork"].opt!bool;
+		ret.stats.stars = nfo["stars_count"].opt!uint;
+		ret.stats.watchers = nfo["watchers_count"].opt!uint;
+		ret.stats.forks = nfo["forks_count"].opt!uint;
+		ret.stats.issues = nfo["open_issues_count"].opt!uint; // conflates PRs and Issues
+		return ret;
+	}
+
+	RepositoryFile[] listFiles(string commit_sha, InetPath path)
+	{
+		assert(path.absolute, "Passed relative path to listFiles.");
+		auto url = "/contents"~path.toString()~"?ref="~commit_sha;
+		auto ls = readJsonFromRepo(url).get!(Json[]);
+		RepositoryFile[] ret;
+		ret.reserve(ls.length);
+		foreach (entry; ls) {
+			string type = entry["type"].get!string;
+			RepositoryFile file;
+			if (type == "dir") {
+				file.type = RepositoryFile.Type.directory;
+			}
+			else if (type == "file") {
+				file.type = RepositoryFile.Type.file;
+				file.size = entry["size"].get!size_t;
+			}
+			else continue;
+			file.commitSha = commit_sha;
+			file.path = InetPath("/" ~ entry["path"].get!string);
+			ret ~= file;
+		}
+		return ret;
+	}
+
+	void readFile(string commit_sha, InetPath path, scope void delegate(scope InputStream) @safe reader)
+	{
+		assert(path.absolute, "Passed relative path to readFile.");
+		auto url = getContentURLPrefix()~m_owner~"/"~m_project~"/raw/commit/"~commit_sha~path.toString();
+		downloadCached(url, (scope input) {
+			reader(input);
+		}, true, &addAuthentication);
+	}
+
+	string getDownloadUrl(string ver)
+	{
+		import std.uri : encodeComponent;
+		if( ver.startsWith("~") ) ver = ver[1 .. $];
+		else ver = ver;
+		auto venc = () @trusted { return encodeComponent(ver); } ();
+		return m_url~m_owner~"/"~m_project~"/archive/"~venc~".zip";
+	}
+
+	void download(string ver, scope void delegate(scope InputStream) @safe del)
+	{
+		downloadCached(getDownloadUrl(ver), del, false, &addAuthentication);
+	}
+
+	private Json readJsonFromRepo(string api_path, bool sanitize = false, bool cache_priority = false)
+	{
+		return readJson(getAPIURLPrefix()~"repos/"~m_owner~"/"~m_project~api_path,
+			sanitize, cache_priority, &addAuthentication);
+	}
+
+	private Json[] readPagedListFromRepo(string api_path, bool sanitize = false, bool cache_priority = false)
+	{
+		return readPagedList(getAPIURLPrefix()~"repos/"~m_owner~"/"~m_project~api_path,
+			sanitize, cache_priority, &addAuthentication);
+	}
+
+	private void addAuthentication(scope HTTPClientRequest req)
+	{
+		req.headers["Authorization"] = "token " ~ m_authToken;
+	}
+
+	private string getAPIURLPrefix()
+	{
+		return m_url ~ "api/v1/";
+	}
+
+	private string getContentURLPrefix()
+	{
+		return m_url;
+	}
+}
+
+package Json[] readPagedList(string url, bool sanitize = false, bool cache_priority = false, RequestModifier request_modifier = null)
+@safe {
+	import dubregistry.internal.utils : black;
+	import std.array : appender;
+	import std.format : format;
+	import vibe.stream.operations : readAllUTF8;
+
+	auto ret = appender!(Json[]);
+	Exception ex;
+	string next = url;
+
+	NextLoop: while (next.length) {
+		logDiagnostic("Getting paged JSON response from %s", next.black);
+		foreach (i; 0 .. 2) {
+			try {
+				downloadCached(next, (scope input, scope headers) {
+					scope (failure) clearCacheEntry(url);
+					next = getNextLink(headers);
+
+					auto text = input.readAllUTF8(sanitize);
+					ret ~= parseJsonString(text).get!(Json[]);
+				}, ["Link"], cache_priority, request_modifier);
+				continue NextLoop;
+			} catch (FileNotFoundException e) {
+				throw e;
+			} catch (Exception e) {
+				logDiagnostic("Failed to parse downloaded JSON document (attempt #%s): %s", i+1, e.msg);
+				ex = e;
+			}
+		}
+		throw new Exception(format("Failed to read JSON from %s: %s", url.black, ex.msg), __FILE__, __LINE__, ex);
+	}
+
+	return ret.data;
+}
+
+private string getNextLink(scope string[string] headers)
+@safe {
+	import uritemplate : expandTemplateURIString;
+	import std.algorithm : endsWith, splitter, startsWith;
+
+	static immutable string startPart = `<`;
+	static immutable string endPart = `>; rel="next"`;
+
+	if (auto link = "Link" in headers) {
+		foreach (part; (*link).splitter(", ")) {
+			if (part.startsWith(startPart) && part.endsWith(endPart)) {
+				return expandTemplateURIString(part[startPart.length .. $ - endPart.length], null);
+			}
+		}
+	}
+	return null;
+}

--- a/source/dubregistry/repositories/gitea.d
+++ b/source/dubregistry/repositories/gitea.d
@@ -157,7 +157,7 @@ class GiteaRepository : Repository {
 	{
 		assert(path.absolute, "Passed relative path to listFiles.");
 		auto url = "/contents"~path.toString()~"?ref="~commit_sha;
-		auto ls = readJsonFromRepo(url).get!(Json[]);
+		auto ls = readJsonFromRepo(url, false, true).get!(Json[]);
 		RepositoryFile[] ret;
 		ret.reserve(ls.length);
 		foreach (entry; ls) {

--- a/source/dubregistry/repositories/gitea.d
+++ b/source/dubregistry/repositories/gitea.d
@@ -116,8 +116,7 @@ class GiteaRepository : Repository {
 		foreach_reverse (tag; tags) {
 			try {
 				auto tagname = tag["name"].get!string;
-				Json commit = readJsonFromRepo("/commits/"~tag["commit"]["sha"].get!string~"/status", true, true);
-				ret ~= RefInfo(tagname, tag["commit"]["sha"].get!string, SysTime.fromISOExtString(commit["statuses"][0]["created_at"].get!string));
+				ret ~= RefInfo(tagname, tag["commit"]["sha"].get!string, SysTime.fromISOExtString(tag["commit"]["created"].get!string));
 				logDebug("Found tag for %s/%s: %s", m_owner, m_project, tagname);
 			} catch( Exception e ){
 				throw new Exception("Failed to process tag "~tag["name"].get!string~": "~e.msg);
@@ -134,8 +133,7 @@ class GiteaRepository : Repository {
 		RefInfo[] ret;
 		foreach_reverse( branch; branches ){
 			auto branchname = branch["name"].get!string;
-			Json commit = readJsonFromRepo("/commits/"~branch["commit"]["id"].get!string~"/status", true, true);
-			ret ~= RefInfo(branchname, branch["commit"]["id"].get!string, SysTime.fromISOExtString(commit["statuses"][0]["created_at"].get!string));
+			ret ~= RefInfo(branchname, branch["commit"]["id"].get!string, SysTime.fromISOExtString(branch["commit"]["timestamp"].get!string));
 			logDebug("Found branch for %s/%s: %s", m_owner, m_project, branchname);
 		}
 		return ret;

--- a/source/dubregistry/repositories/github.d
+++ b/source/dubregistry/repositories/github.d
@@ -17,20 +17,36 @@ import vibe.http.client : HTTPClientRequest;
 import vibe.inet.url;
 
 
+class GithubRepositoryProvider : RepositoryProvider {
+	private {
+		string m_token;
+	}
+@safe:
+
+	private this(string token)
+	{
+		m_token = token;
+	}
+
+	static void register(string token)
+	{
+		auto h = new GithubRepositoryProvider(token);
+		addRepositoryProvider("github", h);
+	}
+
+	Repository getRepository(DbRepository repo)
+	@safe {
+		return new GithubRepository(repo.owner, repo.project, m_token);
+	}
+}
+
+
 class GithubRepository : Repository {
 @safe:
 	private {
 		string m_owner;
 		string m_project;
 		string m_authToken;
-	}
-
-	static void register(string token)
-	{
-		Repository factory(DbRepository info) @safe {
-			return new GithubRepository(info.owner, info.project, token);
-		}
-		addRepositoryFactory("github", &factory);
 	}
 
 	this(string owner, string project, string auth_token)

--- a/source/dubregistry/repositories/gitlab.d
+++ b/source/dubregistry/repositories/gitlab.d
@@ -19,6 +19,30 @@ import vibe.inet.url;
 import vibe.textfilter.urlencode;
 
 
+class GitLabRepositoryProvider : RepositoryProvider {
+	private {
+		string m_token;
+		string m_url;
+	}
+
+	private this(string token, string url)
+	{
+		m_token = token;
+		m_url = url;
+	}
+
+	static void register(string auth_token, string url)
+	{
+		addRepositoryProvider("gitlab", new GitLabRepositoryProvider(auth_token, url));
+	}
+
+	Repository getRepository(DbRepository repo)
+	@safe {
+		return new GitLabRepository(repo.owner, repo.project, m_token, m_url.length ? URL(m_url) : URL("https://gitlab.com/"));
+	}
+
+}
+
 class GitLabRepository : Repository {
 @safe:
 
@@ -27,14 +51,6 @@ class GitLabRepository : Repository {
 		string m_projectPath;
 		URL m_baseURL;
 		string m_authToken;
-	}
-
-	static void register(string auth_token, string url)
-	{
-		Repository factory(DbRepository info) @safe {
-			return new GitLabRepository(info.owner, info.project, auth_token, url.length ? URL(url) : URL("https://gitlab.com/"));
-		}
-		addRepositoryFactory("gitlab", &factory);
 	}
 
 	this(string owner, string projectPath, string auth_token, URL base_url)

--- a/source/dubregistry/repositories/repository.d
+++ b/source/dubregistry/repositories/repository.d
@@ -26,6 +26,13 @@ Repository getRepository(DbRepository repinfo)
 	return rep;
 }
 
+
+/** Adds a new provider to support for accessing repositories.
+
+	Note that currently only one provider instance of each `kind` may be used,
+	because the `kind` value is used to identify the provider as opposed to its
+	URL.
+*/
 void addRepositoryProvider(string kind, RepositoryProvider factory)
 @safe {
 	assert(kind !in s_repositoryProviders);

--- a/source/dubregistry/repositories/repository.d
+++ b/source/dubregistry/repositories/repository.d
@@ -37,9 +37,42 @@ bool supportsRepositoryKind(string kind)
 	return (kind in s_repositoryProviders) !is null;
 }
 
+/** Attempts to parse a URL that points to a repository.
+
+	Throws:
+		Will throw an exception if the URL corresponds to a registered
+		repository provider, but does not point to a repository.
+
+	Returns:
+		`true` is returned $(EM iff) the URL corresponds to any registered
+		repository provider.
+*/
+bool parseRepositoryURL(URL url, out DbRepository repo)
+{
+	foreach (kind, h; s_repositoryProviders)
+		if (h.parseRepositoryURL(url, repo)) {
+			assert(repo.kind == kind);
+			return true;
+		}
+	return false;
+}
 
 
 interface RepositoryProvider {
+	/** Attempts to parse a URL that points to a repository.
+
+		Throws:
+			Will throw an exception if the URL corresponds to the repository
+			provider, but does not point to a repository.
+
+		Returns:
+			`true` is returned $(EM iff) the URL corresponds to the repository
+			provider.
+	*/
+	bool parseRepositoryURL(URL url, out DbRepository repo) @safe;
+
+	/** Creates a `Repository` instance corresponding to the given repository.
+	*/
 	Repository getRepository(DbRepository repo) @safe;
 }
 

--- a/source/dubregistry/repositories/repository.d
+++ b/source/dubregistry/repositories/repository.d
@@ -19,26 +19,29 @@ Repository getRepository(DbRepository repinfo)
 		return *pr;
 
 	logDebug("Returning new repository: %s", repinfo);
-	auto pf = repinfo.kind in s_repositoryFactories;
+	auto pf = repinfo.kind in s_repositoryProviders;
 	enforce(pf, "Unknown repository type: "~repinfo.kind);
-	auto rep = (*pf)(repinfo);
+	auto rep = pf.getRepository(repinfo);
 	s_repositories[repinfo] = rep;
 	return rep;
 }
 
-void addRepositoryFactory(string kind, RepositoryFactory factory)
+void addRepositoryProvider(string kind, RepositoryProvider factory)
 @safe {
-	assert(kind !in s_repositoryFactories);
-	s_repositoryFactories[kind] = factory;
+	assert(kind !in s_repositoryProviders);
+	s_repositoryProviders[kind] = factory;
 }
 
 bool supportsRepositoryKind(string kind)
 @safe {
-	return (kind in s_repositoryFactories) !is null;
+	return (kind in s_repositoryProviders) !is null;
 }
 
 
-alias RepositoryFactory = Repository delegate(DbRepository) @safe;
+
+interface RepositoryProvider {
+	Repository getRepository(DbRepository repo) @safe;
+}
 
 interface Repository {
 @safe:
@@ -115,5 +118,5 @@ package Json readJson(string url, bool sanitize = false, bool cache_priority = f
 
 private {
 	Repository[DbRepository] s_repositories;
-	RepositoryFactory[string] s_repositoryFactories;
+	RepositoryProvider[string] s_repositoryProviders;
 }

--- a/source/dubregistry/web.d
+++ b/source/dubregistry/web.d
@@ -637,11 +637,15 @@ class DubRegistryFullWebFrontend : DubRegistryWebFrontend {
 	@auth @path("/register_package") @errorDisplay!getRegisterPackage
 	void postRegisterPackage(string url, User _user, bool ignore_fork = false)
 	{
-		import std.algorithm.searching : canFind;
+		import std.algorithm.comparison : among;
+		import dubregistry.repositories.repository : parseRepositoryURL;
+
+		auto urls = parseUserURL(url, "https");
+		if (!urls.schema.among!("http", "https"))
+			throw new Exception("Invalid repository schema: Only 'http' and 'https' are supported");
 		DbRepository rep;
-		if (!url.canFind("://"))
-			url = "https://" ~ url;
-		rep.parseURL(URL.fromString(url));
+		if (!parseRepositoryURL(urls, rep)) // FIXME: query the actually registered providers here
+			throw new Exception("The provided URL does not match any supported provider (GitHub/BitBucket/GitLab)");
 
 		string kind = rep.kind;
 		string owner = rep.owner;

--- a/views/my_packages.package.dt
+++ b/views/my_packages.package.dt
@@ -131,6 +131,8 @@ block body
 							option(value="bitbucket", selected=rkind == "bitbucket", disabled=!permSource) Bitbucket
 						- if (supportsRepositoryKind("gitlab"))
 							option(value="gitlab", selected=rkind == "gitlab", disabled=!permSource) GitLab
+						- if (supportsRepositoryKind("gitea"))
+							option(value="gitea", selected=rkind == "gitea", disabled=!permSource) Gitea
 				p
 					label(for="owner") Repository owner:
 					input(type="text", name="owner", value=pack["repository"]["owner"].get!string, disabled=!permSource)


### PR DESCRIPTION
Also Refactors the repository factory logic to enable proper matching of repository URLs to providers, so that local provider instances can be supported properly.

The `GiteaRepository` implementation is an adjusted version of `GithubRepository`, as the APIs are very similar.