### PR TITLE
Correct README instructions on how to run a mirror

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Importing a one-time snapshot from the registry
 You can download a dump of all packages and import it into your local registry for development:
 
 ```
-curl https://code.dlang.org/api/packages/dump | gunzip > mirror.json
+curl https://code.dlang.org/api/packages/dump > mirror.json
 dub -- --mirror=mirror.json
 ```
 


### PR DESCRIPTION
The endpoint actually returns everything as JSON,
which is an obvious DoS vector.