### PR TITLE
Reduce the scope of import in dubregistry.dbcontroller

### DIFF
--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -6,13 +6,22 @@
 module dubregistry.dbcontroller;
 
 import dub.semver;
+
+import vibe.core.log;
+import vibe.db.mongo.collection;
+
 import std.array;
 import std.algorithm;
+import std.conv;
+import std.datetime.systime;
+import std.datetime.timezone;
 import std.exception;
-//import std.string;
+import std.format;
+import std.string;
 import std.typecons : tuple;
 import std.uni;
-import vibe.vibe;
+
+import core.time;
 
 
 class DbController {


### PR DESCRIPTION
Instead of importing vibe.vibe, do more fine-grained imports.