### PR TITLE
Remove dpldocs link, it no longer functions.

### DIFF
--- a/views/view_package.dt
+++ b/views/view_package.dt
@@ -111,7 +111,6 @@ block body
 			- auto doc_url = packinfo.info["documentationURL"].get!string;
 			- if (doc_url.length)
 				a.tab.external(href=doc_url, target="_blank") Documentation
-			a.tab.external(href=text("https://",normalizedPackageName,".dpldocs.info/",versionInfo["version"].get!string,"/"), target="_blank") Reference
 		- bool renderedTabContent;
 		- if (activeTab == "info")
 			- if (readmeContents.length)


### PR DESCRIPTION
![image](https://github.com/dlang/dub-registry/assets/580778/2f97fae2-f4b1-4eff-8257-c6abafaff4f1)

DPLDocs no longer functions as a reference. This removes the link, it can be re-added if it starts working again in the future.