### PR TITLE
🔗 Fixed broken link to package scoring in viewutils.d

### DIFF
--- a/source/dubregistry/viewutils.d
+++ b/source/dubregistry/viewutils.d
@@ -79,7 +79,7 @@ string formatFuzzyDate(SysTime st)
 
 string formatScore(float score)
 {
-	return format(`<a href="https://dub.pm/develop#package-scoring">%.1f</a>`, score);
+	return format(`<a href="https://dub.pm/dub-guide/publishing/#package-scoring">%.1f</a>`, score);
 }
 
 string formatPackageStats(Stats)(Stats s)


### PR DESCRIPTION

This PR fixes the broken link that was pointing to an outdated URL for package scoring information.

#### 🔍 **Details of Changes:**
- **File Updated:** `source/dubregistry/viewutils.d`
- **Old Link:**  
  ```
  https://dub.pm/develop#package-scoring
  ```
- **New Link:**  
  ```
  https://dub.pm/dub-guide/publishing/#package-scoring
  ```
- The updated link correctly points to the section explaining how package scores are computed.

 **Reason for Change:**
- The old link resulted in a 404 error, leading to a broken user experience.
- This update ensures that users can now access the correct documentation.

 **Related Issue:**
- Closes [[#85](https://github.com/dlang/dub-registry/issues/85)](https://github.com/dlang/dub-registry/issues/85) — Broken link to packages' scores.

