### PR TITLE
Reduce GC pressure to mitigate recent outages caused AI bots

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,4 +26,4 @@ jobs:
           restore-keys: |
             ${{ matrix.dc }}-dub-
       - name: Run Tests
-        run: dub test --override-config="vibe-d:tls/openssl"
+        run: dub test --override-config="vibe-stream:tls/openssl"

--- a/dub.sdl
+++ b/dub.sdl
@@ -12,7 +12,7 @@ dependency "userman" version="~>0.4.0"
 dependency "uritemplate" version="~>1.0.0"
 subConfiguration "dub" "library-nonet"
 
-versions "VibeJsonFieldNames"
+//versions "VibeJsonFieldNames"
 
 configuration "application" {
 	targetType "executable"

--- a/dub.sdl
+++ b/dub.sdl
@@ -6,8 +6,8 @@ authors "Sönke Ludwig" "Martin Nowak" "Anton Fediushin aka ohdatboi" \
 	"see GitHub for more"
 license "BSL-1.0"
 
-dependency "vibe-d" version="~>0.9.7-alpha.3"
-dependency "dub" version="~>1.33.0"
+dependency "vibe-d" version="~>0.10.0"
+dependency "dub" version="~>1.33"
 dependency "userman" version="~>0.4.0"
 dependency "uritemplate" version="~>1.0.0"
 subConfiguration "dub" "library-nonet"

--- a/dub.selections.json
+++ b/dub.selections.json
@@ -1,18 +1,24 @@
 {
 	"fileVersion": 1,
 	"versions": {
-		"diet-ng": "1.8.1",
-		"dub": "1.33.1",
-		"eventcore": "0.9.31",
-		"mir-linux-kernel": "1.0.1",
-		"openssl": "3.3.3",
+		"diet-ng": "1.8.3",
+		"dub": "1.40.0",
+		"eventcore": "0.9.35",
+		"libasync": "0.8.6",
+		"memutils": "1.0.11",
+		"mir-linux-kernel": "1.2.1",
+		"openssl": "3.3.4",
 		"openssl-static": "1.0.5+3.0.8",
 		"stdx-allocator": "2.77.5",
 		"taggedalgebraic": "0.11.23",
 		"uritemplate": "1.0.0",
-		"userman": "0.4.4",
-		"vibe-container": "1.3.1",
-		"vibe-core": "2.9.0",
-		"vibe-d": "0.9.8"
+		"userman": "0.4.6",
+		"vibe-container": "1.6.0",
+		"vibe-core": "2.10.1",
+		"vibe-d": "0.10.2",
+		"vibe-http": "1.2.2",
+		"vibe-inet": "1.1.1",
+		"vibe-serialization": "1.1.0",
+		"vibe-stream": "1.1.1"
 	}
 }

--- a/source/dubregistry/dbcontroller.d
+++ b/source/dubregistry/dbcontroller.d
@@ -138,6 +138,30 @@ class DbController {
 		return m_packages.find!DbPackage(Bson.emptyObject);
 	}
 
+	auto getShallowPackageDump()
+	{
+		import std.typecons : nullable;
+
+		static immutable fields = Bson([
+			"owner": Bson(1),
+			"name": Bson(1),
+			"repository": Bson(1),
+			"stats": Bson(1),
+			"categories": Bson(1),
+			"logo": Bson(1),
+			"documentationURL": Bson(1),
+			"textScore": Bson(1),
+			"versions.version": Bson(1),
+			"versions.date": Bson(1),
+		]);
+
+		Bson projection = fields;
+		FindOptions options;
+		options.projection = nullable(projection);
+
+		return m_packages.find!DbShallowPackage(Bson.emptyObject, options);
+	}
+
 	auto getUserPackages(BsonObjectID user_id)
 	{
 		return m_packages.find(["owner": user_id], ["name": 1]).map!(p => p["name"].get!string)();
@@ -567,6 +591,24 @@ struct DbPackageVersion {
 	@optional string readme;
 	@optional bool readmeMarkdown;
 	@optional string docFolder;
+}
+
+struct DbShallowPackage {
+	BsonObjectID _id;
+	BsonObjectID owner;
+	string name;
+	DbRepository repository;
+	DBShallowPackageVersion[] versions;
+	DbPackageStats stats;
+	string[] categories;
+	@optional BsonObjectID logo;
+	@optional string documentationURL;
+	@optional float textScore = 0;
+}
+
+struct DBShallowPackageVersion {
+	SysTime date;
+	string version_;
 }
 
 struct DbPackageDownload {

--- a/source/dubregistry/web.d
+++ b/source/dubregistry/web.d
@@ -67,8 +67,13 @@ class DubRegistryWebFrontend {
 		m_registry = registry;
 		m_userman = userman;
 		updateCategories();
-		updatePackageList();
-		setTimer(30.seconds, &updatePackageList, true);
+		runTask(() nothrow {
+			while (true) {
+				try updatePackageList();
+				catch (Exception e) logException(e, "Failed to update package list");
+				sleepUninterruptible(30.seconds);
+			}
+		});
 	}
 
 	private auto searchForPackages(string sort = "updated", string category = null, ulong skip = 0, ulong limit = 20)

--- a/source/dubregistry/web.d
+++ b/source/dubregistry/web.d
@@ -459,7 +459,7 @@ class DubRegistryWebFrontend {
 		PackedStringAllocator strings;
 		auto newpacks = appender!(CachedPackageSlot[]);
 		newpacks.reserve(m_packages.length);
-		foreach (p; m_registry.db.getPackageDump()) {
+		foreach (p; m_registry.db.getShallowPackageDump()) {
 			CachedPackageSlot cp;
 			cp.id = p._id;
 			cp.name = strings.alloc(p.name);


### PR DESCRIPTION
These are some improvements to the amount of GC allocations used during normal operation. The shallow package list and `updatePackageList` execution changes are new changes, since the other changes only helped temporarily.

See also: https://forum.dlang.org/thread/pnlyqzhuddbktbgyytxu@forum.dlang.org