### PR TITLE
CI: use ubuntu-22.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: CI
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         dc: [dmd-latest, ldc-latest]


### PR DESCRIPTION
Ubuntu 20.04 LTS runner will be removed on 2025-04-15.